### PR TITLE
Fix nginx/Docker backend port mismatch (API routed to the wrong backend)

### DIFF
--- a/deployment/algolens.conf
+++ b/deployment/algolens.conf
@@ -35,7 +35,7 @@ server {
 
     # Auth API proxy
     location /auth {
-        proxy_pass http://localhost:5001/auth;
+        proxy_pass http://localhost:5000/auth;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -45,7 +45,7 @@ server {
 
     # Portfolio API proxy
     location /portfolio {
-        proxy_pass http://localhost:5001/portfolio;
+        proxy_pass http://localhost:5000/portfolio;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,10 @@ services:
       - backend-logs:/app/logs
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      # Runs INSIDE the backend container, where gunicorn listens on 5000. The
+      # "5001:5000" mapping above is host-side only, so the internal check must
+      # target 5000 (it was hitting 5001 and always failing).
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## The bug
nginx (`deployment/algolens.conf`) proxied `/auth` and `/portfolio` to `localhost:**5001**`, but the production Docker backend listens on `**5000**` (`docker-compose.prod.yml` publishes `127.0.0.1:5000:5000`; its healthcheck uses 5000).

Port 5001 belongs to the **legacy `algolens-backend.service` systemd unit** — which `DEPLOYMENT.md` and `README.md` explicitly flag as *"do not use — has no DB credentials."* So the live nginx was routing all API traffic to the wrong, credential-less backend.

## Fix
- Repoint both nginx proxies `5001 → 5000`, matching the canonical Docker deployment (ADR-003 D-2, "Docker-compose-prod is canonical").
- Also fixed the **dev** `docker-compose.yml` backend healthcheck: it curled `localhost:5001` from *inside* the container, where gunicorn only listens on 5000, so the check always failed and the container was perpetually `unhealthy`. (The `5001:5000` mapping is host-side only and left as-is.)

## Verification
Config-only change. `nginx -t` should be run on the host after deploy to confirm the config parses (couldn't run it here — no nginx in this environment). Post-deploy, `GET /auth/...` and `/portfolio/...` should now reach the DB-connected backend.

## Note
This does not remove the legacy systemd unit — that's a broader deployment-consolidation task (ADR-003 D-2). This PR just stops nginx from routing to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)