### PR TITLE
Raise client-side password minimum to 12 chars (match backend policy)

### DIFF
--- a/src/components/RegisterView.tsx
+++ b/src/components/RegisterView.tsx
@@ -59,8 +59,9 @@ export function RegisterView({ onBackToLogin }: RegisterViewProps) {
       return;
     }
 
-    if (password.length < 4) {
-      setError('Password must be at least 4 characters');
+    // Mirror the server-side policy (backend enforces >= 12; this is UX only).
+    if (password.length < 12) {
+      setError('Password must be at least 12 characters');
       return;
     }
 


### PR DESCRIPTION
`RegisterView` accepted passwords as short as **4 characters**. The backend hardening PR adds a server-side 12-character minimum; this mirrors it client-side so users get immediate feedback instead of a round-trip 400.

The server remains authoritative — this check is UX only and can be bypassed (which is why the backend enforcement is the important half).

One-line change (`< 4` → `< 12` + message). Pairs with the backend password-policy PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)