### PR TITLE
Move JWT auth from localStorage to httpOnly cookie + CSRF

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -156,6 +156,27 @@ from datetime import timedelta
 
 app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(seconds=43200)
 
+# --- Token transport: httpOnly cookies instead of a JS-readable body token ---
+# The access token is delivered to the browser as an httpOnly cookie, so front-end
+# JavaScript can never read it. This removes the XSS token-theft vector that came
+# with storing the JWT in localStorage. Because the browser now sends the cookie
+# automatically, we enable double-submit CSRF protection: flask-jwt-extended also
+# sets a companion, NON-httpOnly `csrf_access_token` cookie whose value the client
+# must echo in the `X-CSRF-TOKEN` header on every state-changing (non-safe) request
+# to a protected route. GET/HEAD/OPTIONS are exempt, so the read-only portfolio
+# endpoints need no CSRF header.
+app.config["JWT_TOKEN_LOCATION"] = ["cookies"]
+# HTTPS-only in production; allow plain http on localhost during development.
+app.config["JWT_COOKIE_SECURE"] = IS_PRODUCTION
+# The SPA and the API are served from the same site (same registrable domain behind
+# nginx), so Lax both works and stops the cookie from riding cross-site requests.
+app.config["JWT_COOKIE_SAMESITE"] = "Lax"
+app.config["JWT_COOKIE_CSRF_PROTECT"] = True
+# Persist for the token's lifetime rather than dying when the tab closes, matching
+# the previous localStorage behaviour.
+app.config["JWT_SESSION_COOKIE"] = False
+app.config["JWT_ACCESS_COOKIE_PATH"] = "/"
+
 jwt = JWTManager(app)
 limiter.init_app(app)
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,5 +1,11 @@
 from flask import Blueprint, request, jsonify, current_app
-from flask_jwt_extended import create_access_token
+from flask_jwt_extended import (
+    create_access_token,
+    set_access_cookies,
+    unset_jwt_cookies,
+    jwt_required,
+    get_jwt_identity,
+)
 from werkzeug.security import check_password_hash, generate_password_hash
 from database import execute_query
 from extensions import limiter
@@ -68,40 +74,11 @@ def login():
             f"Login successful for email: {email}, role: {user.get('role', 'general_member')}"
         )
 
-        return jsonify(
-            {
-                "token": access_token,
-                "user": {
-                    "id": user["id"],
-                    "email": user["email"],
-                    "first_name": user.get("first_name"),
-                    "last_name": user.get("last_name"),
-                    "role": user.get("role", "general_member"),
-                },
-            }
-        ), 200
-
-    except Exception as e:
-        current_app.logger.error(f"Login error: {str(e)}", exc_info=True)
-        return jsonify({"error": "An internal error occurred during login"}), 500
-
-
-@auth_bp.route("/verify", methods=["GET"])
-def verify():
-    from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
-
-    @jwt_required()
-    def verify_token():
-        current_user_id = get_jwt_identity()
-        claims = get_jwt()
-
-        query = "SELECT * FROM auth.users WHERE id = %s"
-        user = execute_query(query, (current_user_id,), fetch_one=True)
-
-        if not user:
-            return jsonify({"error": "User not found"}), 404
-
-        return jsonify(
+        # Deliver the token as an httpOnly cookie (plus the CSRF companion cookie).
+        # The token is intentionally NOT returned in the body -- putting it there
+        # would re-introduce the JS-readable token we are removing. The client reads
+        # its logged-in identity from the `user` object and, on reload, from /verify.
+        resp = jsonify(
             {
                 "user": {
                     "id": user["id"],
@@ -111,9 +88,54 @@ def verify():
                     "role": user.get("role", "general_member"),
                 }
             }
-        ), 200
+        )
+        set_access_cookies(resp, access_token)
+        return resp, 200
 
-    return verify_token()
+    except Exception as e:
+        current_app.logger.error(f"Login error: {str(e)}", exc_info=True)
+        return jsonify({"error": "An internal error occurred during login"}), 500
+
+
+@auth_bp.route("/verify", methods=["GET"])
+@jwt_required()
+def verify():
+    """Return the current user, authenticated via the httpOnly access cookie.
+
+    The SPA calls this on load to restore the session: because the token lives in an
+    httpOnly cookie the front-end JavaScript cannot read it, so it asks the server
+    who it is. A missing/expired cookie yields a 401 (handled by the JWT loaders),
+    which the client treats as "logged out" rather than an error.
+    """
+    current_user_id = get_jwt_identity()
+
+    query = "SELECT * FROM auth.users WHERE id = %s"
+    user = execute_query(query, (current_user_id,), fetch_one=True)
+
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    return jsonify(
+        {
+            "user": {
+                "id": user["id"],
+                "email": user["email"],
+                "first_name": user.get("first_name"),
+                "last_name": user.get("last_name"),
+                "role": user.get("role", "general_member"),
+            }
+        }
+    ), 200
+
+
+@auth_bp.route("/logout", methods=["POST"])
+def logout():
+    """Clear the auth cookies. Safe to call without a valid session (idempotent);
+    the worst a forged cross-site call can do is log the user out, so no CSRF check
+    or jwt_required is imposed here."""
+    resp = jsonify({"message": "Logged out"})
+    unset_jwt_cookies(resp)
+    return resp, 200
 
 
 @auth_bp.route("/check-email", methods=["POST"])
@@ -223,17 +245,19 @@ def register():
                 },
             )
 
-            return jsonify(
+            # Same cookie-based delivery as /login (see the note there).
+            resp = jsonify(
                 {
-                    "token": access_token,
                     "user": {
                         "id": updated_user["id"],
                         "email": updated_user["email"],
                         "first_name": updated_user.get("first_name"),
                         "last_name": updated_user.get("last_name"),
                         "role": updated_user.get("role", "general_member"),
-                    },
+                    }
                 }
-            ), 201
+            )
+            set_access_cookies(resp, access_token)
+            return resp, 201
     finally:
         conn.close()

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -108,3 +108,70 @@ def test_production_boots_with_valid_config():
     env["CORS_ORIGINS"] = "https://algolens.example.com"
     result = _import_app(env)
     assert result.returncode == 0, result.stderr
+
+
+# --- httpOnly cookie auth transport ------------------------------------------
+
+
+def _fake_user():
+    return {
+        "id": 1,
+        "email": "user@example.com",
+        "password_hash": "irrelevant-because-check-is-stubbed",
+        "first_name": "A",
+        "last_name": "B",
+        "role": "general_member",
+    }
+
+
+def test_cookie_transport_configured():
+    import app as app_module
+
+    cfg = app_module.app.config
+    # Token travels in a cookie only (no Authorization header path), with CSRF on.
+    assert cfg["JWT_TOKEN_LOCATION"] == ["cookies"]
+    assert cfg["JWT_COOKIE_CSRF_PROTECT"] is True
+
+
+def test_login_sets_httponly_cookie_and_no_body_token(client, monkeypatch):
+    import routes.auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "execute_query", lambda *a, **k: _fake_user())
+    monkeypatch.setattr(auth_mod, "check_password_hash", lambda *a, **k: True)
+
+    resp = client.post(
+        "/auth/login",
+        json={"email": "user@example.com", "password": "a" * 12},
+    )
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    # The token must NOT be handed back in the body anymore.
+    assert "token" not in body, f"token leaked into body: {body}"
+    assert body["user"]["email"] == "user@example.com"
+
+    set_cookies = resp.headers.getlist("Set-Cookie")
+    # httpOnly access cookie is present so JS can never read the token...
+    access = [c for c in set_cookies if c.startswith("access_token_cookie=")]
+    assert access, f"expected access_token_cookie; got {set_cookies}"
+    assert "HttpOnly" in access[0], f"access cookie must be HttpOnly: {access[0]}"
+    # ...and a JS-readable CSRF companion cookie is present (deliberately NOT httpOnly).
+    csrf = [c for c in set_cookies if c.startswith("csrf_access_token=")]
+    assert csrf, f"expected csrf_access_token; got {set_cookies}"
+    assert "HttpOnly" not in csrf[0], "CSRF cookie must be readable by JS"
+
+
+def test_verify_requires_session(client):
+    # With no cookie, /verify is a clean 401 (unauthorized loader), not a 500.
+    resp = client.get("/auth/verify")
+    assert resp.status_code == 401
+
+
+def test_logout_clears_cookies(client):
+    resp = client.post("/auth/logout")
+    assert resp.status_code == 200
+    set_cookies = resp.headers.getlist("Set-Cookie")
+    # The access cookie is being cleared (unset_jwt_cookies emits a Set-Cookie for it).
+    assert any(c.startswith("access_token_cookie=") for c in set_cookies), (
+        f"logout should clear access_token_cookie; got {set_cookies}"
+    )

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -36,7 +36,7 @@ export function Dashboard({ onLogout }: DashboardProps) {
     const fetchPortfolioData = async () => {
       console.log('[Dashboard] === Starting fetchPortfolioData ===');
       console.log('[Dashboard] Current URL:', window.location.href);
-      console.log('[Dashboard] Token exists:', !!localStorage.getItem('token'));
+      // Auth is carried by an httpOnly cookie now; JS cannot inspect it here.
 
       try {
         setIsLoading(true);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,10 +10,9 @@ interface User {
 
 interface AuthContextType {
   user: User | null;
-  token: string | null;
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string, firstName: string, lastName: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   isLoading: boolean;
 }
 
@@ -26,44 +25,60 @@ console.log('[AuthContext] Initialized with API_URL:', API_URL);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
-  const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // The access token now lives in an httpOnly cookie that JavaScript cannot read,
+  // so we can no longer restore the session from localStorage. Instead we ask the
+  // server who we are: /auth/verify authenticates via the cookie and returns the
+  // user, or 401 if there is no valid session. `credentials: 'include'` is required
+  // for the browser to send the cookie.
   useEffect(() => {
-    console.log('[AuthContext] Checking for stored credentials');
-    const storedToken = localStorage.getItem('token');
-    const storedUser = localStorage.getItem('user');
+    let cancelled = false;
 
-    if (storedToken && storedUser) {
-      console.log('[AuthContext] Found stored credentials, restoring session');
-      setToken(storedToken);
-      setUser(JSON.parse(storedUser));
-    } else {
-      console.log('[AuthContext] No stored credentials found');
-    }
-    setIsLoading(false);
+    const restoreSession = async () => {
+      console.log('[AuthContext] Restoring session via /auth/verify');
+      try {
+        const response = await fetch(`${API_URL}/auth/verify`, {
+          method: 'GET',
+          credentials: 'include',
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          if (!cancelled) {
+            console.log('[AuthContext] Session restored for user:', data.user?.email);
+            setUser(data.user);
+          }
+        } else {
+          // 401 here just means "not logged in" -- expected, not an error.
+          console.log('[AuthContext] No active session (status', response.status, ')');
+        }
+      } catch (err) {
+        console.warn('[AuthContext] Session check failed (backend unreachable?):', err);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    restoreSession();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const login = async (email: string, password: string) => {
     const loginUrl = `${API_URL}/auth/login`;
-    console.log('[AuthContext] Login attempt started');
-    console.log('[AuthContext] API URL:', loginUrl);
-    console.log('[AuthContext] Email:', email);
+    console.log('[AuthContext] Login attempt started for:', email);
 
     try {
-      console.log('[AuthContext] Sending login request...');
       const response = await fetch(loginUrl, {
         method: 'POST',
+        credentials: 'include', // send/receive the auth cookies
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ email, password }),
       });
-
-      console.log('[AuthContext] Response received');
-      console.log('[AuthContext] Response status:', response.status);
-      console.log('[AuthContext] Response ok:', response.ok);
-      console.log('[AuthContext] Response headers:', Object.fromEntries(response.headers.entries()));
 
       if (!response.ok) {
         const error = await response.json();
@@ -73,46 +88,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       const data = await response.json();
       console.log('[AuthContext] Login successful');
-      console.log('[AuthContext] User data:', { ...data.user, id: data.user.id });
-
-      setToken(data.token);
+      // The token was set as an httpOnly cookie by the server; we only keep the
+      // user profile in memory.
       setUser(data.user);
-
-      localStorage.setItem('token', data.token);
-      localStorage.setItem('user', JSON.stringify(data.user));
-
-      console.log('[AuthContext] Credentials stored in localStorage');
     } catch (error) {
-      console.error('[AuthContext] Login error details:', {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined
-      });
-
       if (error instanceof TypeError && error.message.includes('fetch')) {
         console.error('[AuthContext] Network error - Failed to connect to:', loginUrl);
-        console.error('[AuthContext] This could be due to:');
-        console.error('[AuthContext] 1. CORS issues');
-        console.error('[AuthContext] 2. Backend server not running');
-        console.error('[AuthContext] 3. Incorrect API URL');
-        console.error('[AuthContext] 4. Network/firewall blocking the request');
         throw new Error(`Failed to connect to server at ${API_URL}. Please check if the backend is running.`);
       }
-
       throw error;
     }
   };
 
   const register = async (email: string, password: string, firstName: string, lastName: string) => {
     const registerUrl = `${API_URL}/auth/register`;
-    console.log('[AuthContext] Register attempt started');
-    console.log('[AuthContext] API URL:', registerUrl);
-    console.log('[AuthContext] Email:', email);
+    console.log('[AuthContext] Register attempt started for:', email);
 
     try {
-      console.log('[AuthContext] Sending register request...');
       const response = await fetch(registerUrl, {
         method: 'POST',
+        credentials: 'include', // send/receive the auth cookies
         headers: {
           'Content-Type': 'application/json',
         },
@@ -120,13 +115,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           email,
           password,
           first_name: firstName,
-          last_name: lastName
+          last_name: lastName,
         }),
       });
-
-      console.log('[AuthContext] Response received');
-      console.log('[AuthContext] Response status:', response.status);
-      console.log('[AuthContext] Response ok:', response.ok);
 
       if (!response.ok) {
         const error = await response.json();
@@ -136,41 +127,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       const data = await response.json();
       console.log('[AuthContext] Registration successful');
-
-      setToken(data.token);
       setUser(data.user);
-
-      localStorage.setItem('token', data.token);
-      localStorage.setItem('user', JSON.stringify(data.user));
-
-      console.log('[AuthContext] Credentials stored in localStorage');
     } catch (error) {
-      console.error('[AuthContext] Registration error details:', {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined
-      });
-
       if (error instanceof TypeError && error.message.includes('fetch')) {
         console.error('[AuthContext] Network error - Failed to connect to:', registerUrl);
         throw new Error(`Failed to connect to server at ${API_URL}. Please check if the backend is running.`);
       }
-
       throw error;
     }
   };
 
-  const logout = () => {
+  const logout = async () => {
     console.log('[AuthContext] Logout initiated');
-    setUser(null);
-    setToken(null);
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
-    console.log('[AuthContext] Logout completed');
+    try {
+      // Clear the httpOnly cookies server-side. Best-effort: even if this fails
+      // (e.g. backend unreachable), we still drop the local user state.
+      await fetch(`${API_URL}/auth/logout`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+    } catch (err) {
+      console.warn('[AuthContext] Logout request failed (clearing local state anyway):', err);
+    } finally {
+      setUser(null);
+      console.log('[AuthContext] Logout completed');
+    }
   };
 
   return (
-    <AuthContext.Provider value={{ user, token, login, register, logout, isLoading }}>
+    <AuthContext.Provider value={{ user, login, register, logout, isLoading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/services/portfolioApi.ts
+++ b/src/services/portfolioApi.ts
@@ -69,58 +69,42 @@ export class PortfolioApiService {
       log('error', 'Auth endpoint test FAILED (likely CORS issue):', e);
     }
 
-    // Test 3: Check with token
-    const token = localStorage.getItem('token');
-    if (token) {
-      try {
-        log('info', 'Test 3: Testing with auth token...');
-        const authTestUrl = `${API_BASE_URL}/portfolio/strategies`;
-        const response = await fetch(authTestUrl, {
-          method: 'GET',
-          headers: { 'Authorization': `Bearer ${token}` }
-        });
-        log('info', `Authenticated request response: ${response.status} ${response.statusText}`);
-        if (response.ok) {
-          const data = await response.json();
-          log('info', 'Response data:', data);
-        } else {
-          const text = await response.text();
-          log('error', 'Error response body:', text);
-        }
-      } catch (e) {
-        log('error', 'Authenticated request FAILED:', e);
+    // Test 3: Check the authenticated request using the session cookie
+    try {
+      log('info', 'Test 3: Testing authenticated request with session cookie...');
+      const authTestUrl = `${API_BASE_URL}/portfolio/strategies`;
+      const response = await fetch(authTestUrl, {
+        method: 'GET',
+        credentials: 'include',
+      });
+      log('info', `Authenticated request response: ${response.status} ${response.statusText} (200 if logged in, 401 if not)`);
+      if (response.ok) {
+        const data = await response.json();
+        log('info', 'Response data:', data);
+      } else {
+        const text = await response.text();
+        log('error', 'Error response body:', text);
       }
-    } else {
-      log('warn', 'Test 3 skipped: No auth token found');
+    } catch (e) {
+      log('error', 'Authenticated request FAILED:', e);
     }
 
     log('info', '=== CONNECTIVITY TEST COMPLETE ===');
   }
 
-  private static getAuthToken(): string | null {
-    const token = localStorage.getItem('token');
-    log('info', `Auth token ${token ? 'found' : 'NOT FOUND'} (length: ${token?.length || 0})`);
-    return token;
-  }
-
   private static async fetchWithAuth(url: string): Promise<Response> {
     log('info', `fetchWithAuth called for URL: ${url}`);
 
-    const token = this.getAuthToken();
-
-    if (!token) {
-      log('error', 'No authentication token found in localStorage');
-      throw new Error('No authentication token found');
-    }
-
-    log('info', `Making fetch request to: ${url}`);
-    log('info', `Request headers: Authorization: Bearer ${token.substring(0, 20)}...`);
+    // Auth now travels in an httpOnly cookie, sent automatically by the browser
+    // when `credentials: 'include'` is set. There is no token for JS to read or
+    // attach; a missing/expired cookie simply comes back as 401 (handled below).
+    log('info', `Making credentialed fetch request to: ${url}`);
 
     try {
       const startTime = performance.now();
       const response = await fetch(url, {
+        credentials: 'include',
         headers: {
-          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
       });
@@ -144,11 +128,12 @@ export class PortfolioApiService {
       }
 
       if (!response.ok) {
-        // Handle 401 Unauthorized or 422 JWT decode errors (e.g., old tokens with non-string subject)
+        // Handle 401 Unauthorized or 422 JWT decode errors (e.g., expired/invalid cookie)
         if (response.status === 401 || response.status === 422) {
-          log('warn', `Token error (${response.status}) - clearing credentials and redirecting to login`);
-          localStorage.removeItem('token');
-          localStorage.removeItem('user');
+          log('warn', `Session error (${response.status}) - redirecting to login`);
+          // The cookie is httpOnly, so there is nothing for JS to clear; a full
+          // navigation re-runs AuthContext's /verify check, which will find no
+          // session and render the login view.
           window.location.href = '/login';
           throw new Error('Session expired or invalid. Please log in again.');
         }


### PR DESCRIPTION
## What & why

The access token used to be returned in the login/register JSON body, stored in `localStorage`, and sent as an `Authorization: Bearer` header. **Any XSS on the page could read `localStorage` and steal a valid 12-hour token.** This PR removes that vector: the token is now delivered as an **httpOnly cookie** that JavaScript cannot read, with **double-submit CSRF protection** on the cookie transport.

## ⚠️ Stacked PR + coordinated-deploy requirement
- **Base branch is `security/backend-hardening` (PR #9), not `main`** — this builds directly on the fail-closed JWT config there. Merge #9 first (or merge this into it), then it flows to `main`.
- **Frontend and backend must deploy together.** The token is no longer in the response body, so an old (localStorage) frontend against this backend — or vice versa — will not authenticate. This is a hard cut, by design.

## Backend
- `app.py`: `JWT_TOKEN_LOCATION=["cookies"]`, `JWT_COOKIE_SECURE=True` in production (HTTPS-only), `JWT_COOKIE_SAMESITE="Lax"`, `JWT_COOKIE_CSRF_PROTECT=True`, non-session cookie so it persists for the token's lifetime (matches the old localStorage UX).
- `auth.py`: `/login` and `/register` set the token with `set_access_cookies(...)` and **no longer return it in the body**; new **`POST /auth/logout`** clears the cookies; `/verify` cleaned up to a plain `@jwt_required` route.

## Frontend
- `AuthContext`: no more `localStorage`. Session is restored on load by calling `GET /auth/verify` (a 401 = "logged out", handled gracefully). `login`/`register`/`logout` use `credentials:'include'`. `token` removed from the context (no consumer used it).
- `portfolioApi`: credentialed fetches replace the Bearer header; a 401/422 just redirects to `/login`.

## How CSRF works here
flask-jwt-extended sets a companion **non-httpOnly `csrf_access_token`** cookie. On state-changing (non-safe) requests to protected routes, the client must echo it in `X-CSRF-TOKEN`. All current portfolio endpoints are **GET** (CSRF-exempt), so no client change is needed today; the protection is in place for any future POST/PUT/DELETE.

## Verification
- **Backend: 11/11 tests pass** (7 existing + 4 new) — asserts the httpOnly access cookie + JS-readable CSRF cookie are set, **no token in the body**, `/verify` 401s without a session, and logout clears the cookie.
- **Frontend: `vite build` succeeds** (2239 modules, no errors).

## Not done here (out of scope)
- Refresh-token rotation / sliding sessions — current model keeps the single 12h access token, just in a safer place.
- A real distributed rate-limit store (still the in-memory limiter from #9).