### PR TITLE
CI/CD: test+build gate, deploy gating, Dependabot & CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # Python backend (Flask, gunicorn, etc.)
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, backend]
+
+  # Frontend (React / Vite / Radix / recharts)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, frontend]
+
+  # Backend container image
+  - package-ecosystem: docker
+    directory: /backend
+    schedule:
+      interval: weekly
+    labels: [dependencies, docker]
+
+  # Frontend container image
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, docker]
+
+  # Keep the Actions themselves current
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, ci]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: AlgoLens CI
+
+# Runs the backend and frontend test/build gates on every PR and on pushes to main.
+# The Deploy workflow is chained to this via workflow_run, so a red build here
+# blocks the production deploy.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install pytest
+
+      - name: Run backend tests
+        # The suites are designed to run without a database (fail-closed guards run
+        # in subprocesses; the registry/service tests stub the DB). The guard keeps
+        # this green until the test-bearing PRs land, then it enforces automatically.
+        run: |
+          if [ -d backend/tests ]; then
+            cd backend && python -m pytest tests -q
+          else
+            echo "::warning::backend/tests not present yet — merge the test PRs to enable this gate"
+          fi
+
+  frontend:
+    name: Frontend (build + vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        # --if-present no-ops (green) until the "test" script lands, then runs vitest.
+        run: npm test --if-present

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+# GitHub-native static analysis (SAST) for the Python backend and the TS/JS
+# frontend. Results appear under the repo's Security > Code scanning tab.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * 1" # weekly, Monday 03:00 UTC
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,20 @@
 name: Deploy AlgoLens
 
+# Gated on CI: this runs only after the "AlgoLens CI" workflow completes
+# successfully on main, so a failing test/build never reaches production.
+# workflow_dispatch is kept for manual, on-demand deploys.
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["AlgoLens CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    # Deploy on a green CI run, or when manually triggered.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Deploy to EC2


### PR DESCRIPTION
## Why
AlgoLens had **only** `deploy.yml` — it SSH-deploys to EC2 on every push to `main` with **no tests run first**, and the pytest/vitest suites added in the recent PRs aren't executed anywhere.

## What
- **`ci.yml`** — backend `pytest` + frontend `npm ci && npm run build && npm test` on PRs and pushes to `main`, with a concurrency group to cancel superseded runs.
  - The suites run **without a database** by design (fail-closed guards run in subprocesses; registry/service tests stub the DB).
  - **Transition-safe guards:** the backend step checks for `backend/tests`, and the frontend uses `npm test --if-present`. So this stays green until the test-bearing PRs (#9, #13, #14) merge, then it enforces automatically — no red X on `main` in the meantime.
- **`deploy.yml`** — trigger changed from `push: main` to **`workflow_run`** on *"AlgoLens CI"* completing **successfully**. A failing build can no longer reach production. `workflow_dispatch` retained for manual deploys; the deploy steps themselves are unchanged.
- **`dependabot.yml`** — weekly update PRs for pip (backend), npm, both Docker images, and the Actions. (Today you only get security *alerts*, not update PRs.)
- **`codeql.yml`** — GitHub-native SAST for Python + TS/JS.

## Notes
- All four YAML files validated locally.
- **Recommended follow-up (needs a repo admin, can't be done from a PR):** mark the `Backend (pytest)` and `Frontend (build + vitest)` checks as **required** in branch protection for `main`, so PRs can't merge red.
- No new secrets required. The deploy still uses the existing `EC2_HOST` / `EC2_USER` / `EC2_SSH_KEY`.