### PR TITLE
Add post-deploy health check + issue-on-failure, and Trivy image scanning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   deploy:
     runs-on: ubuntu-24.04
@@ -53,5 +57,63 @@ jobs:
             sudo systemctl restart algolens-backend
             sudo systemctl restart algolens
 
+            echo "Verifying backend health..."
+            # systemctl restart returns before the app has necessarily finished
+            # booting, so "the restart command succeeded" is not the same as "the
+            # app is actually serving requests" -- retry the internal health
+            # endpoint for up to 30s before declaring the deploy failed.
+            #
+            # Port 5001, not 5000: this script deploys via the systemd path
+            # (algolens-backend.service, PORT=5001), which is a DIFFERENT running
+            # instance from the docker-compose path (port 5000) that PR #10 fixed
+            # nginx to route to. ADR-000 DECISION-8 flags this systemd/Docker
+            # split-brain as an open architectural question -- until it's
+            # resolved, this check must match whatever THIS script actually starts.
+            healthy=0
+            for i in $(seq 1 10); do
+              if curl -sf http://localhost:5001/health > /dev/null; then
+                healthy=1
+                break
+              fi
+              sleep 3
+            done
+            if [ "$healthy" -ne 1 ]; then
+              echo "Backend did not report healthy after restart!" >&2
+              exit 1
+            fi
+
             echo "Deployment complete!"
             echo "Site: https://algolens.algogators.com"
+
+      - name: File an issue if the deploy failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Deploy AlgoLens failed (build/restart step, or the post-deploy health check did not pass). Run: ${runUrl}`;
+            const label = "deploy-failure";
+
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+            });
+
+            if (open.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Deploy failed or post-deploy health check did not pass",
+                body,
+                labels: [label],
+              });
+            }

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,58 @@
+name: Trivy Container Scan
+
+# Scans both Docker images (frontend + backend) for known vulnerabilities. This
+# is the one internet-facing, subscriber-facing repo among the 4 AlgoGators
+# repos (public login/JWT auth), making image scanning especially relevant here.
+#
+# Non-blocking for now (exit-code 0): this is the first scan of images that have
+# been running unscanned, so the baseline vulnerability count is unknown. Once
+# triaged, switch to exit-code 1 for CRITICAL to make it a hard gate.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: frontend
+            context: .
+            dockerfile: Dockerfile
+          - name: backend
+            context: ./backend
+            dockerfile: backend/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.name }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: false
+          load: true
+          tags: algolens-${{ matrix.name }}:scan
+
+      - name: Scan ${{ matrix.name }} image with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: algolens-${{ matrix.name }}:scan
+          format: sarif
+          output: trivy-${{ matrix.name }}.sarif
+          severity: CRITICAL,HIGH
+          exit-code: "0"
+
+      - name: Upload ${{ matrix.name }} results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.name }}.sarif
+          category: trivy-${{ matrix.name }}


### PR DESCRIPTION
## Why
The deploy is now gated on CI (#15), but nothing verifies the app actually came back up on the EC2 host afterward — `systemctl restart` can "succeed" while the app crash-loops. Separately, this is the one internet-facing, subscriber-facing repo among the 4 (public login/JWT auth), making container image scanning especially relevant here.

**Base branch is `ci/github-actions` (#15), not `main`** — both PRs touch `deploy.yml`, so this stacks to avoid a conflicting edit.

## 1. Post-deploy health check + issue-on-failure
After restarting services, retries `curl` against the backend's `/health` endpoint for up to 30s before declaring the deploy successful. On any step failure (build, restart, or the health check itself), files a GitHub issue — or comments on the existing open one, to avoid spam on a bad multi-deploy day — using the ambient `GITHUB_TOKEN`.

### ⚠️ Port correction worth flagging
This workflow deploys via the **systemd** path (`systemctl restart algolens-backend`, i.e. `algolens-backend.service`), which sets **`PORT=5001`** — a *different running instance* from the docker-compose path (port 5000) that PR #10 fixed nginx to route to. [ADR-000](../New_Algo_Xander_Sex/adr/ADR-000-cross-repo-contracts.md) DECISION-8 explicitly flags this **systemd/Docker split-brain** as an open, unresolved architectural question. Until that's resolved, this health check targets **5001** to match what this exact script actually starts — using 5000 here would make the check always fail.

## 2. Trivy image scanning (`trivy-scan.yml`, new)
Builds and scans both Docker images (frontend + backend). **Non-blocking for now** (`exit-code 0`) since this is the first scan of images that have been running unscanned — results still upload to the Security tab immediately. Tighten to blocking on `CRITICAL` once triaged.

## Verification
Both workflow YAMLs validated locally; confirmed both Dockerfile paths exist (`Dockerfile`, `backend/Dockerfile`) and confirmed the actual `PORT=5001` value directly from `deployment/algolens-backend.service` rather than assuming.