### PR TITLE
Add Makefile: one-command setup for frontend and backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ build
 # Backend
 __pycache__
 venv
+.venv
+backend/.venv
 
 backend/logs/algolens.log
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+# AlgoLens developer entrypoints.
+#
+# This repo is a hybrid: a Vite/React frontend at the root and a Flask backend
+# under backend/. `make install` sets up both.
+#
+# Fresh clone, first time:
+#     make install        # frontend deps + backend venv + .env scaffold
+#     make dev            # run the frontend dev server
+SHELL := /bin/bash
+
+VENV   := backend/.venv
+VPY    := $(VENV)/bin/python
+VPIP   := $(VENV)/bin/pip
+PYTHON ?= python3
+
+.DEFAULT_GOAL := help
+.PHONY: help install install-frontend install-backend test build dev clean
+
+help: ## Show available targets
+	@echo "AlgoLens -- portfolio dashboard (React frontend + Flask backend)"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+install: install-frontend install-backend ## Install everything (main entrypoint)
+	@echo ""
+	@echo "Ready. Run 'make dev' for the frontend, or 'make test' to run the suites."
+
+install-frontend: ## Install frontend (npm) dependencies
+	@command -v npm >/dev/null 2>&1 || { echo "npm not found. Install Node.js 20+."; exit 1; }
+	@npm ci
+
+install-backend: ## Create the backend venv and install Python dependencies
+	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "$(PYTHON) not found. Install Python 3.11+."; exit 1; }
+	@if [ ! -d $(VENV) ]; then \
+		echo "Creating backend virtualenv at $(VENV)"; \
+		$(PYTHON) -m venv $(VENV); \
+	fi
+	@$(VPIP) install --quiet --upgrade pip
+	@$(VPIP) install --quiet -r backend/requirements.txt
+	@if [ ! -f backend/.env ] && [ -f backend/.env.example ]; then \
+		cp backend/.env.example backend/.env; \
+		echo ""; \
+		echo "Created backend/.env from backend/.env.example -- fill in DB creds and JWT_SECRET_KEY."; \
+	fi
+
+test: ## Run frontend and backend test suites
+	@echo "==> Frontend"
+	@npm test --if-present
+	@echo "==> Backend"
+	@if [ -d backend/tests ]; then \
+		cd backend && .venv/bin/python -m pytest tests -q; \
+	else \
+		echo "backend/tests not present on this branch yet -- skipping."; \
+	fi
+
+build: ## Build the production frontend bundle
+	@npm run build
+
+dev: ## Start the frontend dev server
+	@npm run dev
+
+clean: ## Remove installed dependencies and build output
+	@rm -rf node_modules build $(VENV)
+	@find backend -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+	@echo "Cleaned node_modules, build/, and the backend venv."


### PR DESCRIPTION
Part of a cross-repo pass adding a consistent `make install` to all four AlgoGators repos.

## Why
This repo is a hybrid — Vite/React at the root, Flask under `backend/` — so a fresh clone means setting up two separate toolchains. One command now does both.

## Usage
```bash
make install       # npm ci + backend venv + .env scaffold
make dev           # frontend dev server
make test          # both suites
make build         # production frontend bundle
```

`make help` is the default goal — just run `make`.

## Notes on the implementation
- **Backend deps install into `backend/.venv`, not system Python**, so setting up dev can't pollute the machine's interpreter. Note the existing `.gitignore` had `venv` but that does **not** match `.venv` — so this PR adds the missing entries.
- **`.env` scaffolding is safe to re-run** — copies `backend/.env.example` → `backend/.env` only when the file doesn't already exist, so real credentials are never clobbered.
- **`test` degrades gracefully.** `npm test --if-present` no-ops when there's no test script, and the backend step skips with a message if `backend/tests` is absent. Both suites currently live in separate open PRs (#9, #14), so this keeps the target honest on any branch rather than failing confusingly.

## Verification
`make` isn't available on the authoring machine, so this was tested in a **`python:3.11-slim` container**:
- ✅ Parses under GNU Make 4.3, `make help` renders
- ✅ `backend/.venv` created
- ✅ `backend/.env` scaffolded from `.env.example`
- ✅ **`flask` and `psycopg2` import successfully from the created venv** — i.e. a real dependency install, not just a dry run