### PR TITLE
Fix: dashboard was blending multiple portfolios into one view

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -1,154 +1,225 @@
+import os
+
 from flask import Blueprint, jsonify, current_app
 from flask_jwt_extended import jwt_required
 from database import get_db_connection
 from datetime import datetime
 
-portfolio_bp = Blueprint('portfolio', __name__)
+portfolio_bp = Blueprint("portfolio", __name__)
 
-@portfolio_bp.route('/strategy/<strategy_id>', methods=['GET'])
+# Strategy this dashboard reports on, as stored in the trading tables.
+STRATEGY_ID = "LIVE_TREND_FOLLOWING"
+
+# Which portfolio to report on.
+#
+# trading.positions, trading.equity_curve and trading.live_results are all keyed
+# by portfolio_id AS WELL AS strategy_id -- portfolio_id is part of
+# positions_pkey. LIVE_TREND_FOLLOWING exists in more than one portfolio, so a
+# query that constrains only strategy_id silently mixes them together:
+#
+#   positions     BASE_PORTFOLIO 492 rows (..2025-12-12) + CONSERVATIVE 1702 (..2026-05-03)
+#   equity_curve  BASE 41 + CONSERVATIVE 211 + 2 rows under "Dustin's Portfolio"
+#   live_results  BASE 37 + CONSERVATIVE 211 + 3 rows with NULL portfolio_id
+#
+# Default is CONSERVATIVE_PORTFOLIO because it is the only portfolio still being
+# written: its data runs to 2026-05-03 while BASE_PORTFOLIO stops in late 2025.
+# Override without a code change by setting ALGOLENS_PORTFOLIO_ID.
+PORTFOLIO_ID = os.getenv("ALGOLENS_PORTFOLIO_ID", "CONSERVATIVE_PORTFOLIO")
+
+
+@portfolio_bp.route("/strategy/<strategy_id>", methods=["GET"])
 @jwt_required()
 def get_strategy(strategy_id):
     """Fetch strategy data - only trendfollowing is supported"""
     try:
-        current_app.logger.info(f'Fetching strategy: {strategy_id}')
+        current_app.logger.info(f"Fetching strategy: {strategy_id}")
 
-        if strategy_id == 'trendfollowing':
+        if strategy_id == "trendfollowing":
             return get_live_trend_following_strategy()
         else:
-            return jsonify({'error': 'Strategy not found'}), 404
+            return jsonify({"error": "Strategy not found"}), 404
 
     except Exception as e:
-        current_app.logger.error(f'Error fetching strategy {strategy_id}: {str(e)}', exc_info=True)
-        return jsonify({'error': 'Failed to fetch strategy'}), 500
+        current_app.logger.error(
+            f"Error fetching strategy {strategy_id}: {str(e)}", exc_info=True
+        )
+        return jsonify({"error": "Failed to fetch strategy"}), 500
 
 
 def get_live_trend_following_strategy():
     """Fetch real data for LIVE_TREND_FOLLOWING from database"""
     from flask import current_app
-    current_app.logger.info('[TREND] Starting to fetch LIVE_TREND_FOLLOWING data')
+
+    current_app.logger.info(
+        "[TREND] Fetching %s data for portfolio %s", STRATEGY_ID, PORTFOLIO_ID
+    )
 
     conn = get_db_connection()
-    current_app.logger.info('[TREND] Database connection established')
+    current_app.logger.info("[TREND] Database connection established")
 
     try:
         with conn.cursor() as cursor:
             # 1. Get latest live results for metrics
-            current_app.logger.info('[TREND] Fetching latest live_results...')
-            cursor.execute("""
+            current_app.logger.info("[TREND] Fetching latest live_results...")
+            cursor.execute(
+                """
                 SELECT * FROM trading.live_results
-                WHERE config::jsonb->>'strategy_type' = 'LIVE_TREND_FOLLOWING'
+                WHERE config::jsonb->>'strategy_type' = %s
+                AND portfolio_id = %s
                 ORDER BY date DESC
                 LIMIT 1
-            """)
+            """,
+                (STRATEGY_ID, PORTFOLIO_ID),
+            )
             latest = cursor.fetchone()
-            current_app.logger.info(f'[TREND] Latest results: {latest is not None}')
+            current_app.logger.info(f"[TREND] Latest results: {latest is not None}")
 
             if not latest:
-                current_app.logger.error('[TREND] No live_results found!')
-                return jsonify({'error': 'No data found for strategy'}), 404
+                current_app.logger.error("[TREND] No live_results found!")
+                return jsonify({"error": "No data found for strategy"}), 404
 
             # 2. Get equity curve for historical data
-            current_app.logger.info('[TREND] Fetching equity_curve...')
-            cursor.execute("""
+            current_app.logger.info("[TREND] Fetching equity_curve...")
+            cursor.execute(
+                """
                 SELECT timestamp, equity
                 FROM trading.equity_curve
-                WHERE strategy_id = 'LIVE_TREND_FOLLOWING'
+                WHERE strategy_id = %s
+                AND portfolio_id = %s
                 ORDER BY timestamp ASC
-            """)
+            """,
+                (STRATEGY_ID, PORTFOLIO_ID),
+            )
             equity_curve = cursor.fetchall()
-            current_app.logger.info(f'[TREND] Found {len(equity_curve)} equity curve points')
-            
+            current_app.logger.info(
+                f"[TREND] Found {len(equity_curve)} equity curve points"
+            )
+
             # 3. Get current positions (latest entry per symbol, sorted by notional)
-            current_app.logger.info('[TREND] Fetching positions...')
-            cursor.execute("""
+            current_app.logger.info("[TREND] Fetching positions...")
+            cursor.execute(
+                """
                 SELECT * FROM (
                     SELECT DISTINCT ON (symbol)
                            symbol, quantity, average_price,
                            daily_unrealized_pnl, daily_realized_pnl
                     FROM trading.positions
-                    WHERE strategy_id = 'LIVE_TREND_FOLLOWING'
+                    WHERE strategy_id = %s
+                    AND portfolio_id = %s
                     AND quantity != 0
                     ORDER BY symbol, updated_at DESC
                 ) AS latest_positions
                 ORDER BY ABS(quantity * average_price) DESC
-            """)
+            """,
+                (STRATEGY_ID, PORTFOLIO_ID),
+            )
             positions = cursor.fetchall()
-            current_app.logger.info(f'[TREND] Found {len(positions)} positions')
+            current_app.logger.info(f"[TREND] Found {len(positions)} positions")
 
-            # 4. Get all executions (assume all are for this strategy)
-            current_app.logger.info('[TREND] Fetching executions...')
-            cursor.execute("""
+            # 4. Get recent executions for this strategy and portfolio.
+            # Previously this selected from trading.executions with NO filter at
+            # all, on the assumption that every execution belonged to this
+            # strategy. It does not: the table carries both strategy_id and
+            # portfolio_id, and holds executions for 3 strategy_ids across
+            # BASE_PORTFOLIO (491), CONSERVATIVE_PORTFOLIO (152) and a stray
+            # "Dustin's Portfolio" (1). Unfiltered, the trade list and the
+            # totalTrades metric were reporting other portfolios' trades.
+            current_app.logger.info("[TREND] Fetching executions...")
+            cursor.execute(
+                """
                 SELECT symbol, side, quantity, price,
                        execution_time, commissions_fees
                 FROM trading.executions
+                WHERE strategy_id = %s
+                AND portfolio_id = %s
                 ORDER BY execution_time DESC
                 LIMIT 100
-            """)
+            """,
+                (STRATEGY_ID, PORTFOLIO_ID),
+            )
             executions = cursor.fetchall()
-            current_app.logger.info(f'[TREND] Found {len(executions)} executions')
+            current_app.logger.info(f"[TREND] Found {len(executions)} executions")
 
             # 5. Get yesterday's positions for finalized positions comparison
-            current_app.logger.info('[TREND] Fetching yesterday\'s positions...')
-            cursor.execute("""
+            current_app.logger.info("[TREND] Fetching yesterday's positions...")
+            cursor.execute(
+                """
                 SELECT DISTINCT ON (symbol)
                        symbol, quantity, average_price,
                        daily_unrealized_pnl, daily_realized_pnl, updated_at
                 FROM trading.positions
-                WHERE strategy_id = 'LIVE_TREND_FOLLOWING'
+                WHERE strategy_id = %s
+                AND portfolio_id = %s
                 AND updated_at::date = (CURRENT_DATE - INTERVAL '1 day')::date
                 ORDER BY symbol, updated_at DESC
-            """)
+            """,
+                (STRATEGY_ID, PORTFOLIO_ID),
+            )
             yesterday_positions = cursor.fetchall()
-            current_app.logger.info(f'[TREND] Found {len(yesterday_positions)} yesterday positions')
+            current_app.logger.info(
+                f"[TREND] Found {len(yesterday_positions)} yesterday positions"
+            )
 
             # Calculate values
-            current_app.logger.info('[TREND] Calculating values...')
-            initial_equity = float(equity_curve[0]['equity']) if equity_curve else 500000
+            current_app.logger.info("[TREND] Calculating values...")
+            initial_equity = (
+                float(equity_curve[0]["equity"]) if equity_curve else 500000
+            )
             # Round to 500k if very close
             if abs(initial_equity - 500000) < 5000:
                 initial_equity = 500000
 
-            current_app.logger.info(f'[TREND] Initial equity: {initial_equity}')
+            current_app.logger.info(f"[TREND] Initial equity: {initial_equity}")
 
-            current_value = float(latest['current_portfolio_value'])
+            current_value = float(latest["current_portfolio_value"])
             total_return = current_value - initial_equity
             # Calculate return percent from actual values, not database
-            return_percent = (total_return / initial_equity * 100) if initial_equity > 0 else 0
+            return_percent = (
+                (total_return / initial_equity * 100) if initial_equity > 0 else 0
+            )
 
-            current_app.logger.info(f'[TREND] Current value: {current_value}, Return: {return_percent}%')
-            current_app.logger.info(f'[TREND] Total return (P&L): ${total_return}')
+            current_app.logger.info(
+                f"[TREND] Current value: {current_value}, Return: {return_percent}%"
+            )
+            current_app.logger.info(f"[TREND] Total return (P&L): ${total_return}")
 
             # Transform positions
-            current_app.logger.info('[TREND] Transforming positions...')
+            current_app.logger.info("[TREND] Transforming positions...")
             transformed_positions = []
             for pos in positions:
-                notional = abs(float(pos['quantity']) * float(pos['average_price']))
-                transformed_positions.append({
-                    'symbol': pos['symbol'],
-                    'name': pos['symbol'].replace('.v.0', ''),
-                    'shares': float(pos['quantity']),
-                    'quantity': float(pos['quantity']),
-                    'costBasis': float(pos['average_price']),
-                    'currentValue': notional,
-                    'marketPrice': float(pos['average_price']),
-                    'notional': notional,
-                    'percentOfTotal': (notional / current_value * 100) if current_value > 0 else 0
-                })
+                notional = abs(float(pos["quantity"]) * float(pos["average_price"]))
+                transformed_positions.append(
+                    {
+                        "symbol": pos["symbol"],
+                        "name": pos["symbol"].replace(".v.0", ""),
+                        "shares": float(pos["quantity"]),
+                        "quantity": float(pos["quantity"]),
+                        "costBasis": float(pos["average_price"]),
+                        "currentValue": notional,
+                        "marketPrice": float(pos["average_price"]),
+                        "notional": notional,
+                        "percentOfTotal": (notional / current_value * 100)
+                        if current_value > 0
+                        else 0,
+                    }
+                )
 
             # Transform equity curve to historical data
             historical_data = []
             for point in equity_curve:
-                historical_data.append({
-                    'date': point['timestamp'].isoformat(),
-                    'value': float(point['equity'])
-                })
+                historical_data.append(
+                    {
+                        "date": point["timestamp"].isoformat(),
+                        "value": float(point["equity"]),
+                    }
+                )
 
             # Calculate best/worst day and daily returns for win rate
             daily_returns = []
             daily_pnl = []  # Track actual P&L for win rate calculation
             for i in range(1, len(historical_data)):
-                prev_val = historical_data[i-1]['value']
-                curr_val = historical_data[i]['value']
+                prev_val = historical_data[i - 1]["value"]
+                curr_val = historical_data[i]["value"]
                 if prev_val > 0:
                     daily_return = ((curr_val - prev_val) / prev_val) * 100
                     daily_returns.append(daily_return)
@@ -159,11 +230,11 @@ def get_live_trend_following_strategy():
 
             # Calculate max drawdown from equity curve
             max_drawdown = 0
-            peak = historical_data[0]['value'] if historical_data else 0
+            peak = historical_data[0]["value"] if historical_data else 0
             for point in historical_data:
-                if point['value'] > peak:
-                    peak = point['value']
-                drawdown = ((peak - point['value']) / peak) * 100 if peak > 0 else 0
+                if point["value"] > peak:
+                    peak = point["value"]
+                drawdown = ((peak - point["value"]) / peak) * 100 if peak > 0 else 0
                 if drawdown > max_drawdown:
                     max_drawdown = drawdown
 
@@ -185,163 +256,231 @@ def get_live_trend_following_strategy():
             # Transform executions with dates
             transformed_executions = []
             for exec in executions:
-                exec_time = exec['execution_time']
-                transformed_executions.append({
-                    'symbol': exec['symbol'],
-                    'side': exec['side'],
-                    'quantity': float(exec['quantity']),
-                    'price': float(exec['price']),
-                    'notional': float(exec['quantity']) * float(exec['price']),
-                    'commission': float(exec['commissions_fees']),
-                    'date': exec_time.isoformat() if exec_time else None
-                })
+                exec_time = exec["execution_time"]
+                transformed_executions.append(
+                    {
+                        "symbol": exec["symbol"],
+                        "side": exec["side"],
+                        "quantity": float(exec["quantity"]),
+                        "price": float(exec["price"]),
+                        "notional": float(exec["quantity"]) * float(exec["price"]),
+                        "commission": float(exec["commissions_fees"]),
+                        "date": exec_time.isoformat() if exec_time else None,
+                    }
+                )
 
             # Transform yesterday's positions into finalized positions
             # Compare with today's positions to show what changed
-            current_app.logger.info('[TREND] Transforming finalized positions...')
-            today_symbols = {pos['symbol'] for pos in positions}
-            yesterday_symbols = {pos['symbol'] for pos in yesterday_positions}
+            current_app.logger.info("[TREND] Transforming finalized positions...")
+            today_symbols = {pos["symbol"] for pos in positions}
+            yesterday_symbols = {pos["symbol"] for pos in yesterday_positions}
 
             transformed_finalized = []
             for ypos in yesterday_positions:
-                symbol = ypos['symbol']
-                yesterday_qty = float(ypos['quantity'])
-                yesterday_price = float(ypos['average_price'])
+                symbol = ypos["symbol"]
+                yesterday_qty = float(ypos["quantity"])
+                yesterday_price = float(ypos["average_price"])
 
                 # Find today's position for this symbol (if exists)
-                today_pos = next((p for p in positions if p['symbol'] == symbol), None)
-                today_qty = float(today_pos['quantity']) if today_pos else 0
-                today_price = float(today_pos['average_price']) if today_pos else yesterday_price
+                today_pos = next((p for p in positions if p["symbol"] == symbol), None)
+                today_qty = float(today_pos["quantity"]) if today_pos else 0
+                today_price = (
+                    float(today_pos["average_price"]) if today_pos else yesterday_price
+                )
 
                 # Calculate realized P&L from position change
                 qty_change = today_qty - yesterday_qty
                 if qty_change != 0:  # Position changed
-                    realized_pnl = float(ypos['daily_realized_pnl']) if ypos['daily_realized_pnl'] else 0
-                    transformed_finalized.append({
-                        'symbol': symbol.replace('.v.0', ''),
-                        'quantity': yesterday_qty,
-                        'entryPrice': yesterday_price,
-                        'exitPrice': today_price,
-                        'realizedPnL': realized_pnl
-                    })
+                    realized_pnl = (
+                        float(ypos["daily_realized_pnl"])
+                        if ypos["daily_realized_pnl"]
+                        else 0
+                    )
+                    transformed_finalized.append(
+                        {
+                            "symbol": symbol.replace(".v.0", ""),
+                            "quantity": yesterday_qty,
+                            "entryPrice": yesterday_price,
+                            "exitPrice": today_price,
+                            "realizedPnL": realized_pnl,
+                        }
+                    )
 
             # Calculate Sharpe ratio
-            ann_return = float(latest['total_annualized_return'])
-            volatility = float(latest['volatility'])
+            ann_return = float(latest["total_annualized_return"])
+            volatility = float(latest["volatility"])
             sharpe = (ann_return / volatility) if volatility > 0 else 0
 
-            current_app.logger.info('[TREND] Building strategy response...')
+            current_app.logger.info("[TREND] Building strategy response...")
 
             # Build strategy response
             strategy = {
-                'id': 'trendfollowing',
-                'name': 'Trend Following',
-                'description': 'Systematic trend following across multiple futures contracts',
-                'invested': initial_equity,
-                'currentValue': current_value,
-                'return': total_return,
-                'returnPercent': return_percent,
-                'positions': transformed_positions,
-                'historicalData': historical_data,
-                'bestDay': best_day,
-                'worstDay': worst_day,
-                'executions': transformed_executions,
-                'finalizedPositions': transformed_finalized,
-                'managers': ['AlgoLens System'],
-                'lastUpdate': latest['date'].isoformat(),
-                'metrics': {
-                    'volatility': volatility,
-                    'sharpeRatio': sharpe,
-                    'maxDrawdown': max_drawdown,
-                    'winRate': win_rate,
-                    'totalTrades': len(transformed_executions),
-                    'avgWin': avg_win,
-                    'avgLoss': avg_loss,
-                    'profitFactor': profit_factor,
-                    'dailyReturn': float(latest['daily_return']) if latest['daily_return'] else 0,
-                    'cumulativeReturn': return_percent,
-                    'annualizedReturn': ann_return,
-                    'grossLeverage': float(latest['gross_leverage']) if latest['gross_leverage'] is not None else 0,
-                    'netLeverage': float(latest['net_leverage']) if latest['net_leverage'] is not None else 0,
-                    'portfolioLeverage': float(latest['portfolio_leverage']) if latest['portfolio_leverage'] is not None else 0,
-                    'marginPosted': float(latest['margin_posted']) if latest['margin_posted'] is not None else 0,
-                    'equityToMarginRatio': float(latest['equity_to_margin_ratio']) if latest['equity_to_margin_ratio'] is not None else 0,
-                    'marginCushion': float(latest['margin_cushion']) if latest['margin_cushion'] is not None else 0,
-                    'totalNotional': float(latest['gross_notional']) if latest['gross_notional'] is not None else 0,
-                    'unrealizedPnL': float(latest['total_unrealized_pnl']) if latest['total_unrealized_pnl'] is not None else 0,
-                    'realizedPnL': float(latest['total_realized_pnl']) if latest['total_realized_pnl'] is not None else 0,
-                    'totalCommissions': float(latest['total_transaction_costs']) if latest['total_transaction_costs'] is not None else 0,
-                    'netPnL': total_return,
-                    'cashAvailable': float(latest['cash_available']) if latest['cash_available'] is not None else 0,
-                    'currentPortfolioValue': current_value
-                }
+                "id": "trendfollowing",
+                "name": "Trend Following",
+                "description": "Systematic trend following across multiple futures contracts",
+                "invested": initial_equity,
+                "currentValue": current_value,
+                "return": total_return,
+                "returnPercent": return_percent,
+                "positions": transformed_positions,
+                "historicalData": historical_data,
+                "bestDay": best_day,
+                "worstDay": worst_day,
+                "executions": transformed_executions,
+                "finalizedPositions": transformed_finalized,
+                "managers": ["AlgoLens System"],
+                "lastUpdate": latest["date"].isoformat(),
+                "metrics": {
+                    "volatility": volatility,
+                    "sharpeRatio": sharpe,
+                    "maxDrawdown": max_drawdown,
+                    "winRate": win_rate,
+                    "totalTrades": len(transformed_executions),
+                    "avgWin": avg_win,
+                    "avgLoss": avg_loss,
+                    "profitFactor": profit_factor,
+                    "dailyReturn": float(latest["daily_return"])
+                    if latest["daily_return"]
+                    else 0,
+                    "cumulativeReturn": return_percent,
+                    "annualizedReturn": ann_return,
+                    "grossLeverage": float(latest["gross_leverage"])
+                    if latest["gross_leverage"] is not None
+                    else 0,
+                    "netLeverage": float(latest["net_leverage"])
+                    if latest["net_leverage"] is not None
+                    else 0,
+                    "portfolioLeverage": float(latest["portfolio_leverage"])
+                    if latest["portfolio_leverage"] is not None
+                    else 0,
+                    "marginPosted": float(latest["margin_posted"])
+                    if latest["margin_posted"] is not None
+                    else 0,
+                    "equityToMarginRatio": float(latest["equity_to_margin_ratio"])
+                    if latest["equity_to_margin_ratio"] is not None
+                    else 0,
+                    "marginCushion": float(latest["margin_cushion"])
+                    if latest["margin_cushion"] is not None
+                    else 0,
+                    "totalNotional": float(latest["gross_notional"])
+                    if latest["gross_notional"] is not None
+                    else 0,
+                    "unrealizedPnL": float(latest["total_unrealized_pnl"])
+                    if latest["total_unrealized_pnl"] is not None
+                    else 0,
+                    "realizedPnL": float(latest["total_realized_pnl"])
+                    if latest["total_realized_pnl"] is not None
+                    else 0,
+                    "totalCommissions": float(latest["total_transaction_costs"])
+                    if latest["total_transaction_costs"] is not None
+                    else 0,
+                    "netPnL": total_return,
+                    "cashAvailable": float(latest["cash_available"])
+                    if latest["cash_available"] is not None
+                    else 0,
+                    "currentPortfolioValue": current_value,
+                },
             }
 
-            current_app.logger.info('[TREND] Strategy response built successfully')
+            current_app.logger.info("[TREND] Strategy response built successfully")
             return jsonify(strategy), 200
 
     except Exception as e:
-        current_app.logger.error(f'[TREND] Error in get_live_trend_following_strategy: {str(e)}', exc_info=True)
+        current_app.logger.error(
+            f"[TREND] Error in get_live_trend_following_strategy: {str(e)}",
+            exc_info=True,
+        )
         raise
     finally:
         conn.close()
-        current_app.logger.info('[TREND] Database connection closed')
+        current_app.logger.info("[TREND] Database connection closed")
 
 
-@portfolio_bp.route('/strategies', methods=['GET'])
+@portfolio_bp.route("/strategies", methods=["GET"])
 @jwt_required()
 def get_all_strategies():
     """Get summary of all strategies"""
-    current_app.logger.info('[STRATEGIES] === /strategies endpoint called ===')
+    current_app.logger.info("[STRATEGIES] === /strategies endpoint called ===")
 
     try:
         strategies = []
 
         # Add real trendfollowing strategy
-        current_app.logger.info('[STRATEGIES] Attempting database connection...')
+        current_app.logger.info("[STRATEGIES] Attempting database connection...")
         conn = get_db_connection()
-        current_app.logger.info('[STRATEGIES] Database connection successful')
+        current_app.logger.info("[STRATEGIES] Database connection successful")
 
         try:
             with conn.cursor() as cursor:
-                current_app.logger.info('[STRATEGIES] Executing query for LIVE_TREND_FOLLOWING...')
-                cursor.execute("""
+                current_app.logger.info(
+                    "[STRATEGIES] Executing query for LIVE_TREND_FOLLOWING..."
+                )
+                cursor.execute(
+                    """
                     SELECT current_portfolio_value, total_annualized_return,
                            volatility, total_cumulative_return
                     FROM trading.live_results
-                    WHERE config::jsonb->>'strategy_type' = 'LIVE_TREND_FOLLOWING'
+                    WHERE config::jsonb->>'strategy_type' = %s
+                    AND portfolio_id = %s
                     ORDER BY date DESC
                     LIMIT 1
-                """)
+                """,
+                    (STRATEGY_ID, PORTFOLIO_ID),
+                )
                 latest = cursor.fetchone()
-                current_app.logger.info(f'[STRATEGIES] Query result: {latest is not None}')
+                current_app.logger.info(
+                    f"[STRATEGIES] Query result: {latest is not None}"
+                )
 
                 if latest:
-                    current_value = float(latest['current_portfolio_value'])
+                    current_value = float(latest["current_portfolio_value"])
                     initial_equity = 500000  # Known starting value
-                    actual_return_percent = ((current_value - initial_equity) / initial_equity * 100) if initial_equity > 0 else 0
+                    actual_return_percent = (
+                        ((current_value - initial_equity) / initial_equity * 100)
+                        if initial_equity > 0
+                        else 0
+                    )
 
-                    current_app.logger.info(f'[STRATEGIES] Found live_results data: portfolio_value={current_value}, calculated_return={actual_return_percent}%')
-                    sharpe = (float(latest['total_annualized_return']) / float(latest['volatility'])) if float(latest['volatility']) > 0 else 0
-                    strategies.append({
-                        'id': 'trendfollowing',
-                        'name': 'Trend Following',
-                        'currentValue': current_value,
-                        'returnPercent': actual_return_percent,  # Use calculated value
-                        'volatility': float(latest['volatility']),
-                        'sharpeRatio': sharpe,
-                        'annualizedReturn': float(latest['total_annualized_return'])
-                    })
-                    current_app.logger.info(f'[STRATEGIES] Strategy added: trendfollowing')
+                    current_app.logger.info(
+                        f"[STRATEGIES] Found live_results data: portfolio_value={current_value}, calculated_return={actual_return_percent}%"
+                    )
+                    sharpe = (
+                        (
+                            float(latest["total_annualized_return"])
+                            / float(latest["volatility"])
+                        )
+                        if float(latest["volatility"]) > 0
+                        else 0
+                    )
+                    strategies.append(
+                        {
+                            "id": "trendfollowing",
+                            "name": "Trend Following",
+                            "currentValue": current_value,
+                            "returnPercent": actual_return_percent,  # Use calculated value
+                            "volatility": float(latest["volatility"]),
+                            "sharpeRatio": sharpe,
+                            "annualizedReturn": float(
+                                latest["total_annualized_return"]
+                            ),
+                        }
+                    )
+                    current_app.logger.info(
+                        f"[STRATEGIES] Strategy added: trendfollowing"
+                    )
                 else:
-                    current_app.logger.warning('[STRATEGIES] No live_results data found for LIVE_TREND_FOLLOWING')
+                    current_app.logger.warning(
+                        "[STRATEGIES] No live_results data found for LIVE_TREND_FOLLOWING"
+                    )
         finally:
             conn.close()
-            current_app.logger.info('[STRATEGIES] Database connection closed')
+            current_app.logger.info("[STRATEGIES] Database connection closed")
 
-        current_app.logger.info(f'[STRATEGIES] Returning {len(strategies)} strategies')
-        return jsonify({'strategies': strategies}), 200
+        current_app.logger.info(f"[STRATEGIES] Returning {len(strategies)} strategies")
+        return jsonify({"strategies": strategies}), 200
 
     except Exception as e:
-        current_app.logger.error(f'[STRATEGIES] Error fetching strategies: {str(e)}', exc_info=True)
-        return jsonify({'error': f'Failed to fetch strategies: {str(e)}'}), 500
+        current_app.logger.error(
+            f"[STRATEGIES] Error fetching strategies: {str(e)}", exc_info=True
+        )
+        return jsonify({"error": f"Failed to fetch strategies: {str(e)}"}), 500

--- a/backend/tests/test_portfolio_queries.py
+++ b/backend/tests/test_portfolio_queries.py
@@ -1,0 +1,76 @@
+"""Regression guard: every query against the `trading` schema must constrain
+the portfolio it reads from.
+
+Background: trading.positions, equity_curve, live_results and executions are all
+keyed by portfolio_id as well as strategy_id (portfolio_id is part of
+positions_pkey). LIVE_TREND_FOLLOWING exists in more than one portfolio, so a
+query filtering only on strategy_id silently returns a blend of portfolios --
+it does not error, it just reports numbers that belong to no real portfolio.
+
+This scans the backend source rather than executing SQL, so it needs no database
+and no Flask app context, and it keeps working if the queries move between
+modules (e.g. into a service layer).
+"""
+
+import os
+import re
+
+BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Tables that carry a portfolio_id and therefore must always be constrained.
+PORTFOLIO_SCOPED_TABLES = {
+    "trading.positions",
+    "trading.equity_curve",
+    "trading.live_results",
+    "trading.executions",
+}
+
+# A `cursor.execute(...)` call: capture the SQL string literal that follows.
+EXECUTE_RE = re.compile(r"""\.execute\(\s*(?:f?["']{3})(.*?)(?:["']{3})""", re.S)
+
+
+def _python_sources():
+    for root, dirs, files in os.walk(BACKEND_DIR):
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in {"tests", "__pycache__", ".venv", "venv", "temp"}
+        ]
+        for fname in files:
+            if fname.endswith(".py"):
+                yield os.path.join(root, fname)
+
+
+def _portfolio_scoped_queries():
+    """Yield (path, table, sql) for every SQL literal reading a scoped table."""
+    for path in _python_sources():
+        with open(path, encoding="utf-8") as fh:
+            src = fh.read()
+        for match in EXECUTE_RE.finditer(src):
+            sql = match.group(1)
+            for table in PORTFOLIO_SCOPED_TABLES:
+                if re.search(rf"\b(?:FROM|JOIN)\s+{re.escape(table)}\b", sql, re.I):
+                    yield path, table, sql
+
+
+def test_there_are_queries_to_check():
+    """Guard the guard: if the scan finds nothing, the test is silently useless."""
+    found = list(_portfolio_scoped_queries())
+    assert found, (
+        "No queries against portfolio-scoped trading tables were found. Either the "
+        "queries moved in a way this scan does not recognise, or the regex needs "
+        "updating -- do not treat this as a pass."
+    )
+
+
+def test_every_trading_query_constrains_portfolio_id():
+    offenders = []
+    for path, table, sql in _portfolio_scoped_queries():
+        if not re.search(r"\bportfolio_id\s*=", sql, re.I):
+            offenders.append(f"{os.path.relpath(path, BACKEND_DIR)} -> {table}")
+
+    assert not offenders, (
+        "These queries read a portfolio-scoped table without constraining "
+        "portfolio_id, so they will silently blend portfolios together:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
Closes #29.

## The bug
Every query in `portfolio.py` constrained `strategy_id` but **not** `portfolio_id`. All four `trading` tables are keyed by portfolio as well (it's part of `positions_pkey`), and `LIVE_TREND_FOLLOWING` runs in more than one portfolio — so the dashboard was assembling a view from rows belonging to **different portfolios**.

It never errored. It just showed numbers that correspond to no real portfolio, which is worse — wrong numbers get believed.

## Confirmed against the live database (read-only introspection)

| Table | CONSERVATIVE | BASE | Stray |
|---|---|---|---|
| positions | 1,702 → 2026-05-03 | 492 → 2025-12-12 | — |
| equity_curve | 211 → 2026-05-03 | 41 → 2025-11-14 | 2 "Dustin's Portfolio" |
| live_results | 211 → 2026-05-03 | 37 → 2025-11-10 | 3 NULL |
| executions | 152 | **491** | 1 "Dustin's Portfolio" |

## What each query was actually doing
- **`equity_curve`** — returned *every* row for the strategy ordered by timestamp, so the headline chart plotted **three portfolios as a single line**, jumping between them across the Oct–Dec 2025 overlap.
- **`positions`** — `DISTINCT ON (symbol) ... ORDER BY updated_at DESC` picked whichever portfolio wrote that symbol last, **per symbol**. Verified collisions on `6M.v.0`, `MYM.v.0`, `NG.v.0` and others.
- **`executions`** — had **no filter at all** ("assume all are for this strategy"), despite the table carrying both columns and holding 3 strategy_ids across 3 portfolios. **76% of displayed trades belonged to BASE_PORTFOLIO.**
- **`live_results`** — `ORDER BY date DESC LIMIT 1` lands on CONSERVATIVE today *only* because it holds the most recent date. Accidental, not correct — if BASE resumed writing, every headline metric would silently flip.

## The fix
All six queries now constrain **both** strategy and portfolio, passed as bind parameters instead of inlined literals.

Portfolio defaults to **`CONSERVATIVE_PORTFOLIO`** — the only one still being written (data to 2026-05-03; BASE stops in late 2025). Overridable via **`ALGOLENS_PORTFOLIO_ID`** without a code change.

⚠️ **Please confirm CONSERVATIVE_PORTFOLIO is the portfolio this dashboard should report on.** The data makes it the obvious choice, but it's a business call, not a technical one.

## One deliberate behaviour change
Filtering `live_results` by `portfolio_id` excludes **3 rows with NULL portfolio_id** (2025-11-11..14). They sit inside the overlap window and are genuinely ambiguous, so dropping them is correct — flagging it so it isn't a surprise.

## Regression test
Adds a test that scans the backend for **any** query reading a portfolio-scoped `trading` table without constraining `portfolio_id`. It parses source rather than executing SQL, so it needs no database and keeps working when these queries move into a service layer (PR #13).

**Verified red/green:** it fails against the pre-fix code, naming all six offending queries, and passes on the fix.

## Follow-ups (not in this PR)
- **PR #13** moves these queries into a service layer and would reintroduce the bug — I'll push the same fix to that branch so merge order doesn't matter.
- Making portfolio an explicit, user-visible selection (rather than a config default) belongs with the strategy-registry work.
- The stray `"Dustin's Portfolio"` rows and the `_` vs `&` strategy-id inconsistency are data-quality issues worth cleaning up separately.