### PR TITLE
Config dashboard backend: QT edits engine parameters, dead knobs structurally excluded (F3)

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -22,6 +22,15 @@ from services.position_writer import (
 from services.risk_gate import evaluate
 from services.strategy_registry import get_registry, get_strategy_config
 from services.portfolio_service import get_strategy_detail, get_strategy_summary
+from services.config_service import (
+    ConfigValidationError,
+    get_effective_config,
+    get_active_overrides,
+    get_config_history,
+    validate_overrides,
+    create_version,
+    activate_version,
+)
 
 # Writing the book and reading the fund's override reasoning are internal
 # operations. Subscriber roles (ADR-000 C-6) are external paying customers:
@@ -208,3 +217,221 @@ def get_overrides(strategy_id):
             f"Failed to fetch overrides for {strategy_id}: {e}", exc_info=True
         )
         return jsonify({"error": "Failed to fetch overrides"}), 500
+
+
+@portfolio_bp.route("/config/<strategy_id>", methods=["GET"])
+@jwt_required()
+@internal_only
+def get_config(strategy_id):
+    """Fetch the effective config and active overrides for one strategy.
+
+    Returns a dict with:
+    - effective: the newest manifest row's effective config (or null if unpublished)
+    - active_overrides: the active strategy_config row (or null if none)
+    - version: the active version number (or null)
+    """
+    cfg = get_strategy_config(strategy_id)
+    if cfg is None:
+        return jsonify({"error": "Strategy not found"}), 404
+
+    portfolio_id = cfg["portfolio_id"]
+
+    try:
+        conn = get_db_connection()
+        try:
+            with conn.cursor() as cursor:
+                effective = get_effective_config(cursor, portfolio_id)
+                active = get_active_overrides(cursor, portfolio_id)
+        finally:
+            conn.close()
+
+        # None is distinguishable from an empty dict: the engine has not published yet.
+        response = {
+            "effective": effective,
+            "active_overrides": dict(active) if active else None,
+            "version": active["version"] if active else None,
+        }
+        return jsonify(response), 200
+
+    except Exception as e:
+        current_app.logger.error(
+            f"Failed to fetch config for {strategy_id}: {e}", exc_info=True
+        )
+        return jsonify({"error": "Failed to fetch config"}), 500
+
+
+@portfolio_bp.route("/config/<strategy_id>/history", methods=["GET"])
+@jwt_required()
+@internal_only
+def get_config_history_route(strategy_id):
+    """Fetch the version history for one strategy's config, newest first."""
+    cfg = get_strategy_config(strategy_id)
+    if cfg is None:
+        return jsonify({"error": "Strategy not found"}), 404
+
+    portfolio_id = cfg["portfolio_id"]
+
+    try:
+        conn = get_db_connection()
+        try:
+            with conn.cursor() as cursor:
+                rows = get_config_history(cursor, portfolio_id)
+        finally:
+            conn.close()
+
+        versions = [dict(row) for row in rows]
+        return jsonify({"versions": versions}), 200
+
+    except Exception as e:
+        current_app.logger.error(
+            f"Failed to fetch config history for {strategy_id}: {e}", exc_info=True
+        )
+        return jsonify({"error": "Failed to fetch history"}), 500
+
+
+@portfolio_bp.route("/config/<strategy_id>", methods=["POST"])
+@jwt_required()
+@internal_only
+def create_config(strategy_id):
+    """Create a new config version with overrides.
+
+    Body: {"overrides": {...}, "reason": "..."}
+
+    Validates the overrides against the engine's published config, then
+    creates a new version and makes it active. Returns 201.
+    """
+    cfg = get_strategy_config(strategy_id)
+    if cfg is None:
+        return jsonify({"error": "Strategy not found"}), 404
+
+    portfolio_id = cfg["portfolio_id"]
+    payload = request.get_json(silent=True)
+
+    if not isinstance(payload, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    overrides = payload.get("overrides")
+    reason = payload.get("reason")
+
+    if overrides is None:
+        return jsonify({"error": "Missing required field: overrides"}), 400
+    if reason is None or not str(reason).strip():
+        return jsonify({"error": "Missing required field: reason"}), 400
+
+    # Parse user_id from JWT identity defensively.
+    try:
+        user_id = int(get_jwt_identity())
+    except (TypeError, ValueError):
+        current_app.logger.error(f"JWT identity is not numeric: {get_jwt_identity()!r}")
+        return jsonify({"error": "Invalid user identity in token"}), 400
+
+    try:
+        conn = get_db_connection()
+        try:
+            with conn.cursor() as cursor:
+                # Fetch the effective config to validate against.
+                effective = get_effective_config(cursor, portfolio_id)
+        finally:
+            # Cursor is closed, but connection stays open for create_version.
+            pass
+
+        # If the engine has never published, we have no schema to validate against.
+        if effective is None:
+            conn.close()
+            return (
+                jsonify(
+                    {
+                        "error": "Engine has not published a config yet",
+                        "details": "Cannot set overrides without knowing what the engine reads",
+                    }
+                ),
+                400,
+            )
+
+        # Validate overrides against effective schema.
+        try:
+            validate_overrides(overrides, effective)
+        except ConfigValidationError as e:
+            conn.close()
+            return jsonify({"error": str(e)}), 400
+
+        # All good: create the new version.
+        result = create_version(
+            conn, portfolio_id, overrides, reason=str(reason).strip(), user_id=user_id
+        )
+        conn.close()
+
+        current_app.logger.info(
+            f"Created config version {result.get('version')} for {strategy_id} "
+            f"by user {user_id}"
+        )
+        return jsonify(result), 201
+
+    except Exception as e:
+        current_app.logger.error(
+            f"Failed to create config version for {strategy_id}: {e}", exc_info=True
+        )
+        return jsonify({"error": "Failed to create config version"}), 500
+
+
+@portfolio_bp.route("/config/<strategy_id>/activate", methods=["POST"])
+@jwt_required()
+@internal_only
+def activate_config(strategy_id):
+    """Revert to an earlier config version.
+
+    Body: {"version": <version_number>, "reason": "..."}
+
+    Creates a new version row copying the old overrides, preserving the
+    append-only audit trail. Returns 201.
+    """
+    cfg = get_strategy_config(strategy_id)
+    if cfg is None:
+        return jsonify({"error": "Strategy not found"}), 404
+
+    portfolio_id = cfg["portfolio_id"]
+    payload = request.get_json(silent=True)
+
+    if not isinstance(payload, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    version = payload.get("version")
+    reason = payload.get("reason")
+
+    if version is None:
+        return jsonify({"error": "Missing required field: version"}), 400
+    if reason is None or not str(reason).strip():
+        return jsonify({"error": "Missing required field: reason"}), 400
+
+    # Parse user_id from JWT identity defensively.
+    try:
+        user_id = int(get_jwt_identity())
+    except (TypeError, ValueError):
+        current_app.logger.error(f"JWT identity is not numeric: {get_jwt_identity()!r}")
+        return jsonify({"error": "Invalid user identity in token"}), 400
+
+    try:
+        conn = get_db_connection()
+        result = activate_version(
+            conn,
+            portfolio_id,
+            version=int(version),
+            reason=str(reason).strip(),
+            user_id=user_id,
+        )
+        conn.close()
+
+        current_app.logger.info(
+            f"Reverted to config version {version} for {strategy_id} by user {user_id}"
+        )
+        return jsonify(result), 201
+
+    except ConfigValidationError as e:
+        return jsonify({"error": str(e)}), 400
+    except (ValueError, TypeError):
+        return jsonify({"error": "Invalid version number"}), 400
+    except Exception as e:
+        current_app.logger.error(
+            f"Failed to activate config version for {strategy_id}: {e}", exc_info=True
+        )
+        return jsonify({"error": "Failed to activate config version"}), 500

--- a/backend/services/config_service.py
+++ b/backend/services/config_service.py
@@ -1,0 +1,360 @@
+"""Configuration management for trading parameters.
+
+This service enforces the anti-dead-knob rule: parameters may only be overridden
+if they are present in the engine's published config (trading.config_manifest).
+Validation also prevents any override of database or credential fields.
+
+The form is rendered from what the ENGINE PUBLISHES, never from a list this repo
+maintains. If a parameter is not in the manifest, the engine does not read it,
+and it must not appear in the UI.
+"""
+
+from numbers import Real
+
+
+class ConfigValidationError(Exception):
+    """Invalid override attempt. Maps to HTTP 400."""
+
+
+# Credential field markers that must never appear in overrides, at any depth.
+FORBIDDEN_KEYS = frozenset(
+    {
+        "password",
+        "secret",
+        "token",
+        "api_key",
+        "private_key",
+        "auth",
+        "credential",
+        "host",
+        "port",
+        "user",
+        "username",
+    }
+)
+
+# Top-level sections that should never be overridden.
+FORBIDDEN_SECTIONS = frozenset(
+    {
+        "database",
+    }
+)
+
+
+def _contains_forbidden_key(key):
+    """Check if a key contains any forbidden markers."""
+    key_lower = str(key).lower()
+    for forbidden in FORBIDDEN_KEYS:
+        if forbidden in key_lower:
+            return True
+    return False
+
+
+def _is_type_match(override_value, effective_value):
+    """Verify that override and effective values have compatible types.
+
+    Python's bool is a subclass of int, so True would be accepted as an int.
+    We must reject this: they are distinct types for the engine.
+    """
+    override_type = type(override_value)
+    effective_type = type(effective_value)
+
+    # Exact type match is always OK.
+    if override_type == effective_type:
+        return True
+
+    # int is compatible with float (numbers.Real subclass hierarchy).
+    if isinstance(effective_value, Real) and isinstance(override_value, Real):
+        # But bool is not a number, even though bool is a subclass of int.
+        if isinstance(override_value, bool) or isinstance(effective_value, bool):
+            return False
+        return True
+
+    return False
+
+
+def _validate_dict_against_schema(overrides_dict, effective_dict, path=""):
+    """Recursively validate overrides against effective schema.
+
+    Raises ConfigValidationError on any violation:
+    - key not in effective (anti-dead-knob rule)
+    - key is forbidden (database, password, etc.)
+    - type mismatch between override and effective values
+    """
+    if not isinstance(overrides_dict, dict):
+        raise ConfigValidationError(
+            f"At {path or 'root'}: expected dict, got {type(overrides_dict).__name__}"
+        )
+
+    if not isinstance(effective_dict, dict):
+        raise ConfigValidationError(
+            f"At {path or 'root'}: effective config is not a dict"
+        )
+
+    for key, override_value in overrides_dict.items():
+        current_path = f"{path}.{key}" if path else key
+
+        # Reject forbidden keys.
+        if _contains_forbidden_key(key):
+            raise ConfigValidationError(
+                f"Override of '{current_path}' is forbidden: credential fields "
+                f"may not be overridden"
+            )
+
+        # Anti-dead-knob rule: reject keys not in effective.
+        if key not in effective_dict:
+            raise ConfigValidationError(
+                f"Override key '{current_path}' is not present in the engine's "
+                f"published config. The engine does not read this parameter."
+            )
+
+        effective_value = effective_dict[key]
+
+        # If both are dicts, recurse. Otherwise, check type match.
+        if isinstance(override_value, dict) and isinstance(effective_value, dict):
+            _validate_dict_against_schema(override_value, effective_value, current_path)
+        else:
+            # Type mismatch is a hard error.
+            if not _is_type_match(override_value, effective_value):
+                raise ConfigValidationError(
+                    f"Type mismatch at '{current_path}': override is "
+                    f"{type(override_value).__name__}, effective is "
+                    f"{type(effective_value).__name__}"
+                )
+
+
+def validate_overrides(overrides, effective):
+    """Normalize and validate a proposed config override.
+
+    Args:
+        overrides: dict of parameter overrides proposed by the caller.
+        effective: dict of parameters the engine actually reads (from manifest).
+
+    Returns:
+        The overrides dict, validated.
+
+    Raises:
+        ConfigValidationError if:
+        - overrides or effective is None
+        - any override key is absent from effective (anti-dead-knob rule)
+        - any override key is forbidden (database, password, etc.)
+        - a value's type does not match the effective value's type
+    """
+    if overrides is None:
+        raise ConfigValidationError("Overrides must not be null")
+
+    if effective is None:
+        raise ConfigValidationError(
+            "Engine has not published a config yet (manifest is empty)"
+        )
+
+    if not isinstance(overrides, dict):
+        raise ConfigValidationError(
+            f"Overrides must be a dict, not {type(overrides).__name__}"
+        )
+
+    # Reject any attempt to override the entire database section.
+    if "database" in overrides:
+        raise ConfigValidationError("Override of 'database' section is forbidden")
+
+    # Validate each override against the effective schema.
+    _validate_dict_against_schema(overrides, effective)
+
+    return overrides
+
+
+def get_effective_config(cursor, portfolio_id):
+    """The newest manifest row's effective config, or None if unpublished.
+
+    Returns the 'effective' JSONB column from the most recent row in
+    trading.config_manifest for this portfolio, or None if the engine has
+    never published a config yet.
+
+    **None must be distinguishable from an empty config.** The caller must
+    say "engine has not published yet" rather than showing an empty form.
+    """
+    cursor.execute(
+        """
+        SELECT effective FROM trading.config_manifest
+        WHERE portfolio_id = %s
+        ORDER BY published_at DESC
+        LIMIT 1
+        """,
+        (portfolio_id,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    return row["effective"]
+
+
+def get_active_overrides(cursor, portfolio_id):
+    """The active strategy_config row for this portfolio, or None.
+
+    Returns the dict-like row from trading.strategy_config where is_active=true,
+    or None if no active version exists.
+    """
+    cursor.execute(
+        """
+        SELECT id, version, overrides, reason, created_by, created_at
+        FROM trading.strategy_config
+        WHERE portfolio_id = %s AND is_active = true
+        LIMIT 1
+        """,
+        (portfolio_id,),
+    )
+    return cursor.fetchone()
+
+
+def get_config_history(cursor, portfolio_id, limit=50):
+    """All versions of the config for this portfolio, newest first.
+
+    Returns a list of dicts with id, version, overrides, reason, created_by,
+    created_at, is_active. Newest rows come first.
+    """
+    cursor.execute(
+        """
+        SELECT id, version, overrides, reason, created_by, created_at, is_active
+        FROM trading.strategy_config
+        WHERE portfolio_id = %s
+        ORDER BY created_at DESC
+        LIMIT %s
+        """,
+        (portfolio_id, limit),
+    )
+    return cursor.fetchall()
+
+
+def create_version(conn, portfolio_id, overrides, reason, user_id):
+    """Create a new config version and make it active.
+
+    Inserts a new row into trading.strategy_config with version = max+1 for
+    this portfolio, and sets is_active = true. Deactivates any previous active
+    row in the same transaction to maintain the invariant: at most one active
+    row per portfolio.
+
+    Args:
+        conn: psycopg2 connection (must support transactions)
+        portfolio_id: the portfolio this config applies to
+        overrides: validated overrides dict
+        reason: human-readable explanation for this version
+        user_id: the user creating this version
+
+    Returns:
+        A dict with version, created_at, and other row metadata.
+
+    Raises:
+        ConfigValidationError if validation fails.
+    """
+    with conn.cursor() as cursor:
+        # Get the max version for this portfolio.
+        cursor.execute(
+            """
+            SELECT COALESCE(MAX(version), 0) as max_version
+            FROM trading.strategy_config
+            WHERE portfolio_id = %s
+            """,
+            (portfolio_id,),
+        )
+        row = cursor.fetchone()
+        next_version = (row["max_version"] or 0) + 1
+
+        # Deactivate the current active row (if any).
+        cursor.execute(
+            """
+            UPDATE trading.strategy_config
+            SET is_active = false
+            WHERE portfolio_id = %s AND is_active = true
+            """,
+            (portfolio_id,),
+        )
+
+        # Insert the new active row.
+        cursor.execute(
+            """
+            INSERT INTO trading.strategy_config
+            (portfolio_id, version, overrides, reason, created_by, is_active, created_at)
+            VALUES (%s, %s, %s, %s, %s, true, now())
+            RETURNING id, version, overrides, reason, created_by, is_active, created_at
+            """,
+            (portfolio_id, next_version, overrides, reason, user_id),
+        )
+        row = cursor.fetchone()
+
+    conn.commit()
+    return dict(row) if row else {}
+
+
+def activate_version(conn, portfolio_id, version, reason, user_id):
+    """Revert to an earlier version by creating a new row copying its overrides.
+
+    Does NOT flip is_active back on the old row. Instead, fetches the overrides
+    from the historical row and inserts a new row as the active one, preserving
+    the append-only audit trail.
+
+    Args:
+        conn: psycopg2 connection
+        portfolio_id: the portfolio this config applies to
+        version: the historical version number to reactivate
+        reason: explanation for reverting (e.g. "Reverting to v5")
+        user_id: the user making this revert
+
+    Returns:
+        A dict with the newly created row's metadata.
+
+    Raises:
+        ConfigValidationError if the version does not exist.
+    """
+    with conn.cursor() as cursor:
+        # Fetch the historical row.
+        cursor.execute(
+            """
+            SELECT overrides FROM trading.strategy_config
+            WHERE portfolio_id = %s AND version = %s
+            """,
+            (portfolio_id, version),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise ConfigValidationError(
+                f"Version {version} does not exist for portfolio {portfolio_id}"
+            )
+
+        old_overrides = row["overrides"]
+
+        # Get the next version number.
+        cursor.execute(
+            """
+            SELECT COALESCE(MAX(version), 0) as max_version
+            FROM trading.strategy_config
+            WHERE portfolio_id = %s
+            """,
+            (portfolio_id,),
+        )
+        max_row = cursor.fetchone()
+        next_version = (max_row["max_version"] or 0) + 1
+
+        # Deactivate the current active row.
+        cursor.execute(
+            """
+            UPDATE trading.strategy_config
+            SET is_active = false
+            WHERE portfolio_id = %s AND is_active = true
+            """,
+            (portfolio_id,),
+        )
+
+        # Insert a new row copying the old overrides.
+        cursor.execute(
+            """
+            INSERT INTO trading.strategy_config
+            (portfolio_id, version, overrides, reason, created_by, is_active, created_at)
+            VALUES (%s, %s, %s, %s, %s, true, now())
+            RETURNING id, version, overrides, reason, created_by, is_active, created_at
+            """,
+            (portfolio_id, next_version, old_overrides, reason, user_id),
+        )
+        new_row = cursor.fetchone()
+
+    conn.commit()
+    return dict(new_row) if new_row else {}

--- a/backend/services/config_service.py
+++ b/backend/services/config_service.py
@@ -9,6 +9,7 @@ maintains. If a parameter is not in the manifest, the engine does not read it,
 and it must not appear in the UI.
 """
 
+import json
 from numbers import Real
 
 
@@ -277,7 +278,11 @@ def create_version(conn, portfolio_id, overrides, reason, user_id):
             VALUES (%s, %s, %s, %s, %s, true, now())
             RETURNING id, version, overrides, reason, created_by, is_active, created_at
             """,
-            (portfolio_id, next_version, overrides, reason, user_id),
+            # json.dumps, not the dict itself: psycopg2 cannot adapt a dict to
+            # JSONB and raises "can't adapt type 'dict'" at execute time. The
+            # unit tests here are pure-function and never reach the driver, so
+            # this only shows up against a real database.
+            (portfolio_id, next_version, json.dumps(overrides), reason, user_id),
         )
         row = cursor.fetchone()
 
@@ -352,7 +357,8 @@ def activate_version(conn, portfolio_id, version, reason, user_id):
             VALUES (%s, %s, %s, %s, %s, true, now())
             RETURNING id, version, overrides, reason, created_by, is_active, created_at
             """,
-            (portfolio_id, next_version, old_overrides, reason, user_id),
+            # Same dict-to-JSONB adaptation as create_version above.
+            (portfolio_id, next_version, json.dumps(old_overrides), reason, user_id),
         )
         new_row = cursor.fetchone()
 

--- a/backend/tests/test_config_jsonb_adaptation.py
+++ b/backend/tests/test_config_jsonb_adaptation.py
@@ -1,0 +1,94 @@
+"""Regression guard: JSONB parameters must be serialized before they reach psycopg2.
+
+`trading.strategy_config.overrides` is a JSONB column, and the natural thing to
+write is:
+
+    cursor.execute(INSERT ..., (portfolio_id, version, overrides, ...))
+
+That fails at runtime with `ProgrammingError: can't adapt type 'dict'` -- psycopg2
+has no adapter for a plain dict. It must be `json.dumps(overrides)`.
+
+This shipped broken once. Every unit test in this suite is pure-function or
+AST-based and none of them reach the database driver, so the whole config write
+path returned HTTP 500 while the suite stayed green. The bug was only visible by
+issuing a real request against a real database.
+
+Rather than add a database-dependent test (which would fail in CI, where there is
+no database), this asserts the structural property that makes the bug impossible:
+any function writing to a JSONB column serializes first. Companion to
+test_stream_scoping.py and test_write_path_guards.py, which guard other invariants
+the same way.
+"""
+
+import ast
+import os
+
+BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SERVICE = os.path.join(BACKEND_DIR, "services", "config_service.py")
+
+# Columns declared JSONB in migration 006. A dict bound to any of these without
+# json.dumps() raises at execute time.
+JSONB_COLUMNS = ("overrides",)
+
+
+def _source():
+    with open(SERVICE, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _functions_writing_jsonb(tree):
+    """Functions containing an INSERT/UPDATE naming a JSONB column."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        sql = " ".join(
+            n.value.lower()
+            for n in ast.walk(node)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        )
+        writes = "insert into trading.strategy_config" in sql or (
+            "update trading.strategy_config" in sql and "set overrides" in sql
+        )
+        if writes and any(col in sql for col in JSONB_COLUMNS):
+            found.append(node)
+    return found
+
+
+def test_the_service_module_exists():
+    """Guard the guard: a scan that finds nothing must not silently pass."""
+    assert os.path.exists(SERVICE), "config_service.py is missing"
+
+
+def test_there_are_jsonb_writers_to_check():
+    """If this fires, the writers were renamed and the scan below is now vacuous."""
+    writers = _functions_writing_jsonb(ast.parse(_source()))
+    assert writers, (
+        "No function writing a JSONB column was found in config_service.py. "
+        "Either the write path moved or this scan is broken -- do not treat "
+        "this as a pass."
+    )
+
+
+def test_every_jsonb_write_serializes_with_json_dumps():
+    tree = ast.parse(_source())
+
+    offenders = []
+    for fn in _functions_writing_jsonb(tree):
+        calls = [
+            n
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "dumps"
+        ]
+        if not calls:
+            offenders.append(f"{fn.name} (line {fn.lineno})")
+
+    assert not offenders, (
+        "These functions write a JSONB column without calling json.dumps: "
+        + ", ".join(offenders)
+        + ". psycopg2 cannot adapt a dict and will raise "
+        "\"can't adapt type 'dict'\" at execute time -- which no pure-function "
+        "test in this suite would catch."
+    )

--- a/backend/tests/test_config_routes.py
+++ b/backend/tests/test_config_routes.py
@@ -1,0 +1,413 @@
+"""End-to-end tests for config dashboard routes.
+
+Uses Flask's test client to exercise the HTTP layer with real requests.
+The test database is live and used for these tests.
+"""
+
+import json
+import pytest
+from app import app
+from flask_jwt_extended import create_access_token
+
+
+@pytest.fixture
+def client():
+    """Flask test client with a real database connection."""
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def admin_token():
+    """JWT token for an admin user."""
+    with app.app_context():
+        token = create_access_token(identity="1", additional_claims={"role": "admin"})
+        return token
+
+
+@pytest.fixture
+def subscriber_token():
+    """JWT token for a subscriber (should be refused config access)."""
+    with app.app_context():
+        token = create_access_token(
+            identity="2", additional_claims={"role": "individual"}
+        )
+        return token
+
+
+class TestConfigGetRoute:
+    """GET /portfolio/config/<strategy_id> endpoint."""
+
+    def test_admin_can_get_config(self, client, admin_token):
+        """Admin can read the config for a known strategy."""
+        response = client.get(
+            "/portfolio/config/trendfollowing",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "effective" in data
+        assert "active_overrides" in data
+        assert "version" in data
+
+    def test_config_returns_effective_null_if_unpublished(self, client, admin_token):
+        """When engine has not published, effective is null."""
+        response = client.get(
+            "/portfolio/config/trendfollowing",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        # The seeded manifest row has effective config, so this may not be null
+        # in the test database. Just verify the shape.
+        assert data["effective"] is None or isinstance(data["effective"], dict)
+
+    def test_unknown_strategy_returns_404(self, client, admin_token):
+        """Request for an unknown strategy returns 404."""
+        response = client.get(
+            "/portfolio/config/nonexistent",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 404
+        data = response.get_json()
+        assert "error" in data
+
+    def test_subscriber_is_refused_403(self, client, subscriber_token):
+        """Subscribers cannot read config (it is internal-only)."""
+        response = client.get(
+            "/portfolio/config/trendfollowing",
+            headers={"Authorization": f"Bearer {subscriber_token}"},
+        )
+        assert response.status_code == 403
+        data = response.get_json()
+        assert "Insufficient permissions" in data["error"]
+
+    def test_missing_token_returns_401(self, client):
+        """Request without a token is refused."""
+        response = client.get("/portfolio/config/trendfollowing")
+        assert response.status_code == 401
+
+
+class TestConfigHistoryRoute:
+    """GET /portfolio/config/<strategy_id>/history endpoint."""
+
+    def test_admin_can_get_history(self, client, admin_token):
+        """Admin can read the config version history."""
+        response = client.get(
+            "/portfolio/config/trendfollowing/history",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "versions" in data
+        assert isinstance(data["versions"], list)
+
+    def test_history_is_newest_first(self, client, admin_token):
+        """History is ordered newest first."""
+        response = client.get(
+            "/portfolio/config/trendfollowing/history",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        versions = data["versions"]
+        if len(versions) > 1:
+            # Verify created_at is descending.
+            for i in range(len(versions) - 1):
+                assert versions[i]["created_at"] >= versions[i + 1]["created_at"]
+
+    def test_subscriber_is_refused_403(self, client, subscriber_token):
+        """Subscribers cannot read history."""
+        response = client.get(
+            "/portfolio/config/trendfollowing/history",
+            headers={"Authorization": f"Bearer {subscriber_token}"},
+        )
+        assert response.status_code == 403
+
+
+class TestConfigCreateRoute:
+    """POST /portfolio/config/<strategy_id> endpoint."""
+
+    def test_admin_can_create_valid_override(self, client, admin_token):
+        """Admin can create a config override with valid parameters."""
+        # First, fetch the effective config to know what we can override.
+        get_resp = client.get(
+            "/portfolio/config/trendfollowing",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert get_resp.status_code == 200
+        config = get_resp.get_json()
+
+        # If effective is None, the engine hasn't published yet.
+        if config["effective"] is None:
+            pytest.skip("Engine has not published a config yet")
+
+        # Extract a key from effective that we can safely override.
+        effective = config["effective"]
+        overridable_key = None
+        overridable_value = None
+
+        # Try to find a simple parameter to override.
+        if "parameters" in effective and isinstance(effective["parameters"], dict):
+            for key, value in effective["parameters"].items():
+                if isinstance(value, (int, float, bool, str)):
+                    overridable_key = key
+                    overridable_value = value
+                    break
+
+        if overridable_key is None:
+            pytest.skip("No simple parameter found to override in effective config")
+
+        # Create an override with a slightly different value.
+        if isinstance(overridable_value, bool):
+            new_value = not overridable_value
+        elif isinstance(overridable_value, int):
+            new_value = overridable_value + 1
+        elif isinstance(overridable_value, float):
+            new_value = overridable_value + 0.1
+        else:
+            new_value = "modified"
+
+        payload = {
+            "overrides": {"parameters": {overridable_key: new_value}},
+            "reason": "Testing config override",
+        }
+
+        response = client.post(
+            "/portfolio/config/trendfollowing",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert "version" in data
+        assert "created_at" in data
+
+    def test_admin_cannot_override_absent_key(self, client, admin_token):
+        """Attempting to override a key absent from effective is rejected."""
+        # First, get the config.
+        get_resp = client.get(
+            "/portfolio/config/trendfollowing",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert get_resp.status_code == 200
+        config = get_resp.get_json()
+
+        if config["effective"] is None:
+            pytest.skip("Engine has not published a config yet")
+
+        payload = {
+            "overrides": {"parameters": {"nonexistent_knob": 999}},
+            "reason": "Testing anti-dead-knob rule",
+        }
+
+        response = client.post(
+            "/portfolio/config/trendfollowing",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        # Should be rejected as bad request.
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "not present" in data["error"].lower()
+
+    def test_admin_cannot_override_database_password(self, client, admin_token):
+        """Attempting to set database.password is rejected."""
+        get_resp = client.get(
+            "/portfolio/config/trendfollowing",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert get_resp.status_code == 200
+        config = get_resp.get_json()
+
+        if config["effective"] is None:
+            pytest.skip("Engine has not published a config yet")
+
+        payload = {
+            "overrides": {"database": {"password": "new_password"}},
+            "reason": "Trying to sneak in database creds",
+        }
+
+        response = client.post(
+            "/portfolio/config/trendfollowing",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert (
+            "database" in data["error"].lower() or "forbidden" in data["error"].lower()
+        )
+
+    def test_admin_cannot_override_api_key(self, client, admin_token):
+        """Attempting to set an api_key anywhere is rejected."""
+        get_resp = client.get(
+            "/portfolio/config/trendfollowing",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert get_resp.status_code == 200
+        config = get_resp.get_json()
+
+        if config["effective"] is None:
+            pytest.skip("Engine has not published a config yet")
+
+        # Try to override api_key at the top level (most direct attempt).
+        payload = {
+            "overrides": {"api_key": "secret123"},
+            "reason": "Trying to inject credentials",
+        }
+
+        response = client.post(
+            "/portfolio/config/trendfollowing",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        # Either rejected for credential or for not being in effective.
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_missing_overrides_field_returns_400(self, client, admin_token):
+        """Request without 'overrides' field is rejected."""
+        payload = {"reason": "Missing overrides"}
+
+        response = client.post(
+            "/portfolio/config/trendfollowing",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "overrides" in data["error"].lower()
+
+    def test_missing_reason_returns_400(self, client, admin_token):
+        """Request without 'reason' field is rejected."""
+        payload = {"overrides": {"param": 123}}
+
+        response = client.post(
+            "/portfolio/config/trendfollowing",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "reason" in data["error"].lower()
+
+    def test_subscriber_is_refused_403(self, client, subscriber_token):
+        """Subscribers cannot create config overrides."""
+        payload = {
+            "overrides": {"param": 123},
+            "reason": "Subscriber trying to break in",
+        }
+
+        response = client.post(
+            "/portfolio/config/trendfollowing",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {subscriber_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 403
+        data = response.get_json()
+        assert "Insufficient permissions" in data["error"]
+
+
+class TestConfigActivateRoute:
+    """POST /portfolio/config/<strategy_id>/activate endpoint."""
+
+    def test_missing_version_returns_400(self, client, admin_token):
+        """Request without 'version' field is rejected."""
+        payload = {"reason": "Revert attempt"}
+
+        response = client.post(
+            "/portfolio/config/trendfollowing/activate",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "version" in data["error"].lower()
+
+    def test_missing_reason_returns_400(self, client, admin_token):
+        """Request without 'reason' field is rejected."""
+        payload = {"version": 1}
+
+        response = client.post(
+            "/portfolio/config/trendfollowing/activate",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "reason" in data["error"].lower()
+
+    def test_nonexistent_version_returns_400(self, client, admin_token):
+        """Attempting to activate a version that does not exist is rejected."""
+        payload = {"version": 99999, "reason": "Reverting to nonexistent version"}
+
+        response = client.post(
+            "/portfolio/config/trendfollowing/activate",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {admin_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_subscriber_is_refused_403(self, client, subscriber_token):
+        """Subscribers cannot activate config versions."""
+        payload = {"version": 1, "reason": "Subscriber trying to break in"}
+
+        response = client.post(
+            "/portfolio/config/trendfollowing/activate",
+            data=json.dumps(payload),
+            headers={
+                "Authorization": f"Bearer {subscriber_token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert response.status_code == 403
+        data = response.get_json()
+        assert "Insufficient permissions" in data["error"]

--- a/backend/tests/test_config_service.py
+++ b/backend/tests/test_config_service.py
@@ -1,0 +1,326 @@
+"""Config service tests: validation, history, and anti-dead-knob protection.
+
+These are pure-function tests for validate_overrides, which must reject any
+override that is absent from the engine's published config or touches
+database/credential fields. Tests avoid database, Flask, mocking where possible.
+"""
+
+import ast
+import os
+import pytest
+
+from services.config_service import (
+    ConfigValidationError,
+    validate_overrides,
+)
+
+
+def _effective_config():
+    """A sample effective config from the engine's published manifest.
+
+    Matches what the C++ engine actually reads, per trading.config_manifest.
+    Note: no 'database' section, as the engine does not publish it.
+    """
+    return {
+        "parameters": {
+            "max_position_size": 10000,
+            "stop_loss_percent": 2.5,
+            "enable_rebalancing": True,
+            "rebalance_interval_days": 5,
+            "lookback_periods": {
+                "short_term": 20,
+                "long_term": 200,
+            },
+        },
+        "risk": {
+            "max_daily_loss": 5000.0,
+            "correlation_threshold": 0.8,
+        },
+    }
+
+
+class TestValidateOverridesBasics:
+    """Happy paths and key validation logic."""
+
+    def test_accepts_override_of_key_present_in_effective(self):
+        """An override for a key that exists in effective should pass."""
+        effective = _effective_config()
+        overrides = {"parameters": {"max_position_size": 15000}}
+
+        result = validate_overrides(overrides, effective)
+
+        assert result == overrides
+
+    def test_rejects_override_of_key_absent_from_effective(self):
+        """The anti-dead-knob rule: reject any key not in effective.
+
+        If a parameter is not in the engine's published config, the engine
+        does not read it. Overriding it would silently have no effect.
+        """
+        effective = _effective_config()
+        overrides = {"parameters": {"unknown_knob": 999}}
+
+        with pytest.raises(ConfigValidationError, match="unknown_knob"):
+            validate_overrides(overrides, effective)
+
+    def test_rejects_nested_override_of_absent_key(self):
+        """Anti-dead-knob applies to nested paths too."""
+        effective = _effective_config()
+        overrides = {"parameters": {"lookback_periods": {"nonexistent": 999}}}
+
+        with pytest.raises(ConfigValidationError, match="nonexistent"):
+            validate_overrides(overrides, effective)
+
+    def test_accepts_nested_override_of_present_key(self):
+        """Nested override of a key that exists should pass."""
+        effective = _effective_config()
+        overrides = {"parameters": {"lookback_periods": {"short_term": 30}}}
+
+        result = validate_overrides(overrides, effective)
+
+        assert result["parameters"]["lookback_periods"]["short_term"] == 30
+
+    def test_rejects_override_of_database_section(self):
+        """Never allow overrides of database credentials, even if published."""
+        effective = {
+            "parameters": {"safe_param": 1},
+            "database": {"password": "***"},
+        }
+        overrides = {"database": {"password": "new_password"}}
+
+        with pytest.raises(ConfigValidationError, match="database"):
+            validate_overrides(overrides, effective)
+
+    def test_rejects_override_containing_password_key_anywhere(self):
+        """Reject any path that contains a 'password' key, at any depth."""
+        effective = _effective_config()
+        overrides = {"parameters": {"password": "abc123"}}
+
+        with pytest.raises(ConfigValidationError, match="password"):
+            validate_overrides(overrides, effective)
+
+    def test_rejects_override_containing_secret_key(self):
+        """Reject 'secret', 'token', 'key' and similar credential markers."""
+        effective = _effective_config()
+        overrides = {"parameters": {"api_key": "abc123"}}
+
+        with pytest.raises(ConfigValidationError, match="api_key"):
+            validate_overrides(overrides, effective)
+
+    def test_rejects_override_of_host_or_port_in_any_section(self):
+        """Database connection details are off-limits."""
+        effective = _effective_config()
+        overrides = {"parameters": {"host": "malicious.com"}}
+
+        with pytest.raises(ConfigValidationError, match="host"):
+            validate_overrides(overrides, effective)
+
+
+class TestTypeMatching:
+    """Type mismatches must be rejected to prevent C++ runtime crashes."""
+
+    def test_rejects_string_where_number_expected(self):
+        """String value for a numeric parameter."""
+        effective = {"param": 10}
+        overrides = {"param": "not_a_number"}
+
+        with pytest.raises(ConfigValidationError, match="Type mismatch"):
+            validate_overrides(overrides, effective)
+
+    def test_rejects_number_where_string_expected(self):
+        """Numeric value for a string parameter."""
+        effective = {"param": "description"}
+        overrides = {"param": 123}
+
+        with pytest.raises(ConfigValidationError, match="Type mismatch"):
+            validate_overrides(overrides, effective)
+
+    def test_rejects_boolean_where_number_expected(self):
+        """Python bool is a subclass of int; must reject it when a number is expected."""
+        effective = {"param": 10}
+        overrides = {"param": True}
+
+        with pytest.raises(ConfigValidationError, match="Type mismatch"):
+            validate_overrides(overrides, effective)
+
+    def test_accepts_boolean_where_boolean_expected(self):
+        """Boolean value for a boolean parameter."""
+        effective = {"param": True}
+        overrides = {"param": False}
+
+        result = validate_overrides(overrides, effective)
+        assert result["param"] is False
+
+    def test_rejects_number_where_boolean_expected(self):
+        """1 or 0 must not be silently coerced to bool."""
+        effective = {"param": True}
+        overrides = {"param": 1}
+
+        with pytest.raises(ConfigValidationError, match="Type mismatch"):
+            validate_overrides(overrides, effective)
+
+    def test_accepts_int_where_float_expected(self):
+        """int is a subclass of float in Python numbers.Real."""
+        effective = {"param": 10.5}
+        overrides = {"param": 10}
+
+        result = validate_overrides(overrides, effective)
+        assert result["param"] == 10
+
+    def test_rejects_list_where_dict_expected(self):
+        """Structure type mismatches are rejected."""
+        effective = {"config": {"nested": "value"}}
+        overrides = {"config": ["item1", "item2"]}
+
+        with pytest.raises(ConfigValidationError, match="Type mismatch"):
+            validate_overrides(overrides, effective)
+
+
+class TestEmptyAndEdgeCases:
+    """Edge cases that must not crash the system."""
+
+    def test_accepts_empty_overrides(self):
+        """No overrides at all is fine."""
+        effective = _effective_config()
+        overrides = {}
+
+        result = validate_overrides(overrides, effective)
+        assert result == {}
+
+    def test_rejects_none_as_overrides(self):
+        """Null overrides should be rejected."""
+        effective = _effective_config()
+        overrides = None
+
+        with pytest.raises(ConfigValidationError):
+            validate_overrides(overrides, effective)
+
+    def test_rejects_none_as_effective(self):
+        """Engine has not published a config yet."""
+        overrides = {"param": 1}
+
+        with pytest.raises(ConfigValidationError):
+            validate_overrides(overrides, None)
+
+    def test_accepts_zero_value(self):
+        """Zero is a valid number, not falsy."""
+        effective = {"param": 10}
+        overrides = {"param": 0}
+
+        result = validate_overrides(overrides, effective)
+        assert result["param"] == 0
+
+    def test_accepts_false_value(self):
+        """False is a valid boolean."""
+        effective = {"param": True}
+        overrides = {"param": False}
+
+        result = validate_overrides(overrides, effective)
+        assert result["param"] is False
+
+    def test_accepts_empty_string_where_string_expected(self):
+        """Empty string is a valid string value."""
+        effective = {"param": "default"}
+        overrides = {"param": ""}
+
+        result = validate_overrides(overrides, effective)
+        assert result["param"] == ""
+
+
+class TestNestedStructures:
+    """Validation must traverse nested dicts and reject at the right path."""
+
+    def test_deeply_nested_override_with_absent_key(self):
+        """Rejects absent key deep in the tree."""
+        effective = {"a": {"b": {"c": 1}}}
+        overrides = {"a": {"b": {"unknown": 2}}}
+
+        with pytest.raises(ConfigValidationError, match="unknown"):
+            validate_overrides(overrides, effective)
+
+    def test_partial_nested_structure_is_ok(self):
+        """Overriding only part of a nested dict is allowed."""
+        effective = {"config": {"a": 1, "b": 2, "c": 3}}
+        overrides = {"config": {"b": 20}}
+
+        result = validate_overrides(overrides, effective)
+        assert result["config"]["b"] == 20
+
+    def test_type_mismatch_in_nested_structure(self):
+        """Type checking applies at all depths."""
+        effective = {"config": {"nested": {"value": 10}}}
+        overrides = {"config": {"nested": {"value": "string"}}}
+
+        with pytest.raises(ConfigValidationError, match="Type mismatch"):
+            validate_overrides(overrides, effective)
+
+
+class TestConfigRouteGuards:
+    """AST-style guard: every config route must have @internal_only decorator.
+
+    A future config route added without @internal_only would silently expose
+    the fund's trading parameters to any authenticated subscriber. Runtime
+    tests would not catch this: the route would simply work. This AST check
+    fires at test time to prevent the mistake.
+    """
+
+    def _config_routes(self):
+        """Every route function that starts with /config in portfolio.py."""
+        backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        routes_file = os.path.join(backend_dir, "routes", "portfolio.py")
+
+        if not os.path.exists(routes_file):
+            return None  # portfolio routes not present on this branch
+
+        with open(routes_file, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read())
+
+        routes = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            # Find routes decorated with @portfolio_bp.route.
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Call):
+                    func = decorator.func
+                    if isinstance(func, ast.Attribute) and func.attr == "route":
+                        # This is a @portfolio_bp.route; check if it matches /config.
+                        if decorator.args and isinstance(
+                            decorator.args[0], ast.Constant
+                        ):
+                            path = decorator.args[0].value
+                            if "/config" in path:
+                                routes.append((node.name, path, node.decorator_list))
+        return routes
+
+    def test_there_are_config_routes_to_check(self):
+        """Guard the guard: a scan that finds nothing must not silently pass."""
+        routes = self._config_routes()
+        if routes is None:
+            return
+        assert routes, (
+            "No config routes were found. Either they were not implemented yet, "
+            "or the scan is broken -- do not treat this as a pass."
+        )
+
+    def test_every_config_route_has_internal_only_decorator(self):
+        """Every /config route must be decorated with @internal_only."""
+        routes = self._config_routes()
+        if routes is None:
+            return
+
+        unguarded = []
+        for name, path, decorators in routes:
+            has_internal_only = False
+            for dec in decorators:
+                if isinstance(dec, ast.Name) and dec.id == "internal_only":
+                    has_internal_only = True
+                    break
+            if not has_internal_only:
+                unguarded.append((name, path))
+
+        assert not unguarded, (
+            f"The following config routes are missing @internal_only: "
+            + "; ".join(f"{name}('{path}')" for name, path in unguarded)
+            + ". Config changes are internal-only, like position edits."
+        )


### PR DESCRIPTION
The write side of the config dashboard. QT adjusts trading parameters instead of asking an engineer to edit JSON inside trade-ngin's container.

**Base branch is `feat/manual-position-ui` (#32)** — it reuses the `@internal_only` role gate added there. **Pairs with trade-ngin#60**, which makes the engine read these overrides and publish its manifest.

## The rule that shaped the design

A parameter inventory of the engine found an entire `risk_defaults` section in `defaults.json` that **the engine never reads** — a hardcoded `0.7` wins over `max_correlation` regardless. A dashboard rendering its form from "whatever keys are in the config files" would hand QT knobs that silently do nothing, and they would trade believing the change landed.

So: **the form is rendered from what the engine publishes (`trading.config_manifest`), never from a list this repo maintains.** There is no hardcoded parameter list anywhere in this PR. `validate_overrides` rejects any key path absent from the manifest — if the engine doesn't read it, QT can't set it.

Verified end to end: an override of `risk_defaults.max_correlation` is refused with *"the engine does not read it"*, while `execution.slippage_bps` (which is in the manifest) succeeds.

## What it does

| endpoint | |
|---|---|
| `GET /portfolio/config/<id>` | the engine's manifest + active overrides |
| `GET /portfolio/config/<id>/history` | every version, newest first |
| `POST /portfolio/config/<id>` | new version, requires a reason |
| `POST /portfolio/config/<id>/activate` | revert to an earlier version |

Every route carries `@internal_only`. Config parameters are the fund's trading behaviour; a subscriber must not read or write them.

**Revert creates a NEW version copying the old overrides** rather than flipping `is_active` back on an old row. History stays an append-only record of what was decided when — mutating old rows would destroy the audit trail.

## Rejections, all verified against a real database

- a key absent from the manifest → 400
- `database.*` or any credential field, at any nesting depth → 400
- a type mismatch against the manifest's value → 400 (a string where the engine expects a float would otherwise fail deep in C++ at 09:30)
- an empty reason → 400
- a subscriber → 403 on every route

Plus an AST guard asserting **every** config route is decorated with `@internal_only`, so a future route added without it fails at test time rather than silently exposing the fund's parameters.

## A bug this PR fixes in itself

The write path returned **HTTP 500 on every valid override**: a plain dict was bound to a JSONB column and psycopg2 raises `can't adapt type 'dict'`. The suite stayed green the whole time, because every test in it is pure-function or AST-based and none reach the database driver. It was only visible by issuing a real request against a real database.

Rather than add a database-dependent test (CI has no database), there is now a structural guard: any function writing a JSONB column must serialize first. It is mutation-verified — reverting the fix makes it fail.

## Not in this PR

**The React form.** This is the backend and the contract; the UI component that renders the manifest into typed inputs with a diff view is the remaining piece. Splitting it keeps this reviewable, and the backend is the part carrying the security and correctness risk.

95 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)