### PR TITLE
Config dashboard UI: QT edits engine parameters, with running vs pending made unmistakable (F3)

### DIFF
--- a/src/components/ConfigDashboard.tsx
+++ b/src/components/ConfigDashboard.tsx
@@ -1,0 +1,427 @@
+/**
+ * Config dashboard for strategy parameter overrides.
+ *
+ * THE CRITICAL PATTERN: effective (running now) vs active_overrides.overrides (pending at next session).
+ * Every overridden field shows both values, unmistakably. A banner warns when pending changes exist.
+ * A trader who changes a risk parameter must see and confirm it does not take effect immediately.
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTheme } from '../contexts/ThemeContext';
+import { PortfolioApiService, type ConfigResponse } from '../services/portfolioApi';
+import {
+  flattenConfig,
+  mergeOverrides,
+  buildOverridePayload,
+  coerceValue,
+  canSubmitConfig,
+  type FlatConfigField,
+  type MergedField,
+} from '../lib/configEdit';
+import { AlertCircle, Check, X } from 'lucide-react';
+
+interface ConfigDashboardProps {
+  strategyId: string;
+}
+
+export function ConfigDashboard({ strategyId }: ConfigDashboardProps) {
+  const { theme } = useTheme();
+
+  // API state
+  const [config, setConfig] = useState<ConfigResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  // Form state: path -> edited value (or undefined if coerce failed)
+  const [edits, setEdits] = useState<Record<string, any>>({});
+  const [reason, setReason] = useState('');
+
+  // Fetch config on mount
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const data = await PortfolioApiService.getConfig(strategyId);
+        setConfig(data);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        setConfig(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchConfig();
+  }, [strategyId]);
+
+  // Flatten effective into form fields; compute running vs pending
+  const fields = config ? flattenConfig(config.effective) : [];
+  const merged = config ? mergeOverrides(config.effective, config.active_overrides?.overrides ?? null) : {};
+
+  // Whether any field is overridden (pending != running)
+  const hasOverrides = Object.values(merged).some(m => m.isOverridden);
+
+  // Handle input change; coerce based on field type
+  const handleChange = useCallback((path: string, rawValue: string, type: string) => {
+    const coerced = coerceValue(rawValue, type as any);
+    setEdits(prev => ({
+      ...prev,
+      [path]: coerced,
+    }));
+    // Clear success on any change
+    setSubmitSuccess(false);
+  }, []);
+
+  // Submit new config
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError(null);
+    setSubmitSuccess(false);
+
+    if (!config) return;
+
+    // Guard: must have changes and valid reason
+    if (!canSubmitConfig(edits, reason)) {
+      setSubmitError('Please provide a reason and at least one change');
+      return;
+    }
+
+    // Build payload: only include changed values, nested by section
+    const payload = buildOverridePayload(edits, config.effective);
+
+    // Guard: payload must not be empty after build
+    if (Object.keys(payload).length === 0) {
+      setSubmitError('No changes to submit');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await PortfolioApiService.updateConfig(strategyId, {
+        overrides: payload,
+        reason,
+      });
+
+      // Refresh config to show new active_overrides
+      const updated = await PortfolioApiService.getConfig(strategyId);
+      setConfig(updated);
+      setEdits({});
+      setReason('');
+      setSubmitSuccess(true);
+
+      // Clear success message after 3 seconds
+      setTimeout(() => setSubmitSuccess(false), 3000);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [config, edits, reason, strategyId]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className={`flex items-center justify-center py-12 ${
+        theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+      }`}>
+        <div className="text-center">
+          <div className="mb-2">Loading configuration...</div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state: either no permission, or network error
+  if (error) {
+    return (
+      <div className={`rounded-lg border p-6 ${
+        theme === 'dark'
+          ? 'bg-red-950 border-red-800'
+          : 'bg-red-50 border-red-200'
+      }`}>
+        <div className="flex items-start gap-3">
+          <AlertCircle className={`w-5 h-5 flex-shrink-0 ${
+            theme === 'dark' ? 'text-red-400' : 'text-red-600'
+          }`} />
+          <div>
+            <h3 className={`font-semibold mb-1 ${
+              theme === 'dark' ? 'text-red-200' : 'text-red-900'
+            }`}>
+              Cannot Load Configuration
+            </h3>
+            <p className={theme === 'dark' ? 'text-red-300' : 'text-red-800'}>
+              {error}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // No config published yet
+  if (!config) {
+    return (
+      <div className={`rounded-lg border p-6 ${
+        theme === 'dark'
+          ? 'bg-gray-900 border-gray-800'
+          : 'bg-gray-50 border-gray-200'
+      }`}>
+        <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
+          The engine has not published its configuration yet. Please check back once a session has started.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Banner: pending changes exist, will take effect at next session */}
+      {hasOverrides && (
+        <div className={`rounded-lg border p-4 mb-6 flex items-start gap-3 ${
+          theme === 'dark'
+            ? 'bg-amber-950 border-amber-800'
+            : 'bg-amber-50 border-amber-200'
+        }`}>
+          <AlertCircle className={`w-5 h-5 flex-shrink-0 ${
+            theme === 'dark' ? 'text-amber-400' : 'text-amber-600'
+          }`} />
+          <div>
+            <h3 className={`font-semibold ${
+              theme === 'dark' ? 'text-amber-200' : 'text-amber-900'
+            }`}>
+              Pending Changes
+            </h3>
+            <p className={`text-sm ${
+              theme === 'dark' ? 'text-amber-300' : 'text-amber-800'
+            }`}>
+              Configuration changes take effect at the next session start. Current values are running now.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Form */}
+      <form onSubmit={handleSubmit}>
+        {/* Group fields by section */}
+        {Array.from(new Set(fields.map(f => f.section))).map(section => {
+          const sectionFields = fields.filter(f => f.section === section);
+
+          return (
+            <div key={section} className="mb-8">
+              <h3 className={`text-sm font-semibold uppercase tracking-wider mb-4 ${
+                theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+              }`}>
+                {section}
+              </h3>
+
+              <div className="grid gap-4">
+                {sectionFields.map(field => {
+                  const mergedField = merged[field.path];
+                  if (!mergedField) return null;
+
+                  const isOverridden = mergedField.isOverridden;
+                  const currentEditValue = edits[field.path];
+                  const displayEditValue = currentEditValue !== undefined ? currentEditValue : '';
+
+                  return (
+                    <div
+                      key={field.path}
+                      className={`rounded-lg border p-4 ${
+                        theme === 'dark'
+                          ? 'border-gray-800 bg-gray-900'
+                          : 'border-gray-200 bg-white'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between mb-3">
+                        <label className={`text-sm font-medium ${
+                          theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                        }`}>
+                          {field.key}
+                        </label>
+                        {isOverridden && (
+                          <span className={`text-xs font-semibold px-2 py-1 rounded ${
+                            theme === 'dark'
+                              ? 'bg-amber-950 text-amber-200'
+                              : 'bg-amber-100 text-amber-800'
+                          }`}>
+                            PENDING
+                          </span>
+                        )}
+                      </div>
+
+                      {/* Running vs Pending status */}
+                      <div className={`text-xs mb-3 space-y-1 ${
+                        theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                      }`}>
+                        <div>
+                          Running: <span className="font-mono font-semibold">{String(mergedField.running)}</span>
+                        </div>
+                        {isOverridden && (
+                          <div>
+                            Pending: <span className="font-mono font-semibold text-amber-500">{String(mergedField.pending)}</span>
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Input or read-only display */}
+                      {field.type === 'unsupported' ? (
+                        <div className={`px-3 py-2 rounded ${
+                          theme === 'dark'
+                            ? 'bg-gray-800 text-gray-400'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}>
+                          <span className="text-xs">(Read-only: edit in config file)</span>
+                        </div>
+                      ) : field.type === 'boolean' ? (
+                        <label className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={displayEditValue === '' ? mergedField.running : displayEditValue}
+                            onChange={(e) => handleChange(field.path, e.target.checked.toString(), field.type)}
+                            className="rounded"
+                            disabled={isSubmitting}
+                          />
+                          <span className={`text-sm ${
+                            theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                          }`}>
+                            {displayEditValue === '' ? mergedField.running.toString() : displayEditValue.toString()}
+                          </span>
+                        </label>
+                      ) : (
+                        <input
+                          type={field.type === 'number' ? 'number' : 'text'}
+                          value={displayEditValue === '' ? mergedField.running : displayEditValue}
+                          onChange={(e) => handleChange(field.path, e.target.value, field.type)}
+                          step={field.type === 'number' ? 'any' : undefined}
+                          className={`w-full px-3 py-2 rounded border ${
+                            currentEditValue === undefined && displayEditValue !== ''
+                              ? theme === 'dark'
+                                ? 'border-red-700 bg-red-950'
+                                : 'border-red-300 bg-red-50'
+                              : theme === 'dark'
+                                ? 'border-gray-700 bg-gray-800 text-white'
+                                : 'border-gray-300 bg-white text-gray-900'
+                          }`}
+                          disabled={isSubmitting}
+                        />
+                      )}
+
+                      {/* Coerce error feedback */}
+                      {currentEditValue === undefined && displayEditValue !== '' && (
+                        <div className="text-xs text-red-500 mt-2">
+                          Invalid {field.type}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Reason field (mandatory) */}
+        <div className="mb-6">
+          <label className={`block text-sm font-medium mb-2 ${
+            theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+          }`}>
+            Reason for changes <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Describe why you're making these changes..."
+            className={`w-full px-3 py-2 rounded border ${
+              theme === 'dark'
+                ? 'border-gray-700 bg-gray-800 text-white'
+                : 'border-gray-300 bg-white text-gray-900'
+            }`}
+            rows={3}
+            disabled={isSubmitting}
+          />
+        </div>
+
+        {/* Submit messages */}
+        {submitSuccess && (
+          <div className={`rounded-lg border p-4 mb-6 flex items-center gap-2 ${
+            theme === 'dark'
+              ? 'bg-green-950 border-green-800'
+              : 'bg-green-50 border-green-200'
+          }`}>
+            <Check className={`w-5 h-5 ${
+              theme === 'dark' ? 'text-green-400' : 'text-green-600'
+            }`} />
+            <span className={theme === 'dark' ? 'text-green-200' : 'text-green-800'}>
+              Configuration updated successfully. Changes take effect at the next session start.
+            </span>
+          </div>
+        )}
+
+        {submitError && (
+          <div className={`rounded-lg border p-4 mb-6 flex items-start gap-2 ${
+            theme === 'dark'
+              ? 'bg-red-950 border-red-800'
+              : 'bg-red-50 border-red-200'
+          }`}>
+            <X className={`w-5 h-5 flex-shrink-0 ${
+              theme === 'dark' ? 'text-red-400' : 'text-red-600'
+            }`} />
+            <span className={theme === 'dark' ? 'text-red-200' : 'text-red-800'}>
+              {submitError}
+            </span>
+          </div>
+        )}
+
+        {/* Diff summary */}
+        {Object.keys(edits).length > 0 && Object.values(edits).some(v => v !== undefined) && (
+          <div className={`rounded-lg border p-4 mb-6 ${
+            theme === 'dark'
+              ? 'border-gray-700 bg-gray-800'
+              : 'border-gray-300 bg-gray-50'
+          }`}>
+            <h4 className={`text-sm font-semibold mb-3 ${
+              theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+            }`}>
+              Changes to submit
+            </h4>
+            <div className="space-y-1 text-xs font-mono">
+              {Object.entries(edits).map(([path, newValue]) => {
+                if (newValue === undefined) return null;
+                const oldValue = config?.effective[path.split('.')[0]]?.[path.split('.')[1]];
+                if (newValue === oldValue) return null;
+
+                return (
+                  <div key={path} className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
+                    {path}: <span className={theme === 'dark' ? 'text-gray-300' : 'text-gray-900'}>{String(newValue)}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Submit button */}
+        <button
+          type="submit"
+          disabled={!canSubmitConfig(edits, reason) || isSubmitting}
+          className={`px-4 py-2 rounded font-medium transition-colors ${
+            !canSubmitConfig(edits, reason) || isSubmitting
+              ? theme === 'dark'
+                ? 'bg-gray-800 text-gray-500 cursor-not-allowed'
+                : 'bg-gray-200 text-gray-500 cursor-not-allowed'
+              : theme === 'dark'
+                ? 'bg-orange-600 text-white hover:bg-orange-700'
+                : 'bg-orange-500 text-white hover:bg-orange-600'
+          }`}
+        >
+          {isSubmitting ? 'Submitting...' : 'Submit Changes'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/ConfigHistory.tsx
+++ b/src/components/ConfigHistory.tsx
@@ -1,0 +1,313 @@
+/**
+ * Config history: versions from newest to oldest, with revert buttons.
+ * Marks the currently active version clearly.
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTheme } from '../contexts/ThemeContext';
+import { PortfolioApiService, type ConfigHistoryEntry } from '../services/portfolioApi';
+import { AlertCircle, Check, X, RotateCcw } from 'lucide-react';
+
+interface ConfigHistoryProps {
+  strategyId: string;
+}
+
+export function ConfigHistory({ strategyId }: ConfigHistoryProps) {
+  const { theme } = useTheme();
+
+  const [entries, setEntries] = useState<ConfigHistoryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revertingVersion, setRevertingVersion] = useState<number | null>(null);
+  const [revertReason, setRevertReason] = useState('');
+  const [revertError, setRevertError] = useState<string | null>(null);
+  const [revertSuccess, setRevertSuccess] = useState<number | null>(null);
+
+  // Fetch history on mount
+  useEffect(() => {
+    const fetchHistory = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const data = await PortfolioApiService.getConfigHistory(strategyId);
+        setEntries(data.versions);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchHistory();
+  }, [strategyId]);
+
+  // Submit revert
+  const handleRevert = useCallback(async (version: number) => {
+    setRevertError(null);
+    setRevertSuccess(null);
+
+    if (!revertReason.trim()) {
+      setRevertError('Please provide a reason for reverting');
+      return;
+    }
+
+    try {
+      setRevertingVersion(version);
+      await PortfolioApiService.activateConfigVersion(strategyId, {
+        version,
+        reason: revertReason,
+      });
+
+      // Refresh history to show updated is_active flags
+      const data = await PortfolioApiService.getConfigHistory(strategyId);
+      setEntries(data.versions);
+
+      setRevertSuccess(version);
+      setRevertReason('');
+
+      // Clear success message after 3 seconds
+      setTimeout(() => setRevertSuccess(null), 3000);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setRevertError(message);
+    } finally {
+      setRevertingVersion(null);
+    }
+  }, [strategyId, revertReason]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className={`flex items-center justify-center py-12 ${
+        theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+      }`}>
+        <div className="text-center">
+          <div className="mb-2">Loading history...</div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className={`rounded-lg border p-6 ${
+        theme === 'dark'
+          ? 'bg-red-950 border-red-800'
+          : 'bg-red-50 border-red-200'
+      }`}>
+        <div className="flex items-start gap-3">
+          <AlertCircle className={`w-5 h-5 flex-shrink-0 ${
+            theme === 'dark' ? 'text-red-400' : 'text-red-600'
+          }`} />
+          <div>
+            <h3 className={`font-semibold mb-1 ${
+              theme === 'dark' ? 'text-red-200' : 'text-red-900'
+            }`}>
+              Cannot Load History
+            </h3>
+            <p className={theme === 'dark' ? 'text-red-300' : 'text-red-800'}>
+              {error}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (entries.length === 0) {
+    return (
+      <div className={`rounded-lg border p-6 ${
+        theme === 'dark'
+          ? 'bg-gray-900 border-gray-800'
+          : 'bg-gray-50 border-gray-200'
+      }`}>
+        <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
+          No configuration versions yet. Create a change to start the audit trail.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {revertSuccess && (
+        <div className={`rounded-lg border p-4 mb-6 flex items-center gap-2 ${
+          theme === 'dark'
+            ? 'bg-green-950 border-green-800'
+            : 'bg-green-50 border-green-200'
+        }`}>
+          <Check className={`w-5 h-5 ${
+            theme === 'dark' ? 'text-green-400' : 'text-green-600'
+          }`} />
+          <span className={theme === 'dark' ? 'text-green-200' : 'text-green-800'}>
+            Configuration reverted successfully. New version takes effect at the next session start.
+          </span>
+        </div>
+      )}
+
+      {revertError && (
+        <div className={`rounded-lg border p-4 mb-6 flex items-start gap-2 ${
+          theme === 'dark'
+            ? 'bg-red-950 border-red-800'
+            : 'bg-red-50 border-red-200'
+        }`}>
+          <X className={`w-5 h-5 flex-shrink-0 ${
+            theme === 'dark' ? 'text-red-400' : 'text-red-600'
+          }`} />
+          <span className={theme === 'dark' ? 'text-red-200' : 'text-red-800'}>
+            {revertError}
+          </span>
+        </div>
+      )}
+
+      {/* Version list: newest first */}
+      <div className="space-y-4">
+        {entries.map((entry) => (
+          <div
+            key={entry.id}
+            className={`rounded-lg border p-4 ${
+              entry.is_active
+                ? theme === 'dark'
+                  ? 'border-green-800 bg-green-950'
+                  : 'border-green-200 bg-green-50'
+                : theme === 'dark'
+                  ? 'border-gray-800 bg-gray-900'
+                  : 'border-gray-200 bg-white'
+            }`}
+          >
+            <div className="flex items-start justify-between mb-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <h4 className={`font-semibold ${
+                    theme === 'dark' ? 'text-gray-200' : 'text-gray-900'
+                  }`}>
+                    Version {entry.version}
+                  </h4>
+                  {entry.is_active && (
+                    <span className={`text-xs font-semibold px-2 py-1 rounded ${
+                      theme === 'dark'
+                        ? 'bg-green-900 text-green-200'
+                        : 'bg-green-200 text-green-900'
+                    }`}>
+                      ACTIVE
+                    </span>
+                  )}
+                </div>
+
+                <div className={`text-xs mt-1 space-y-0.5 ${
+                  theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                }`}>
+                  <div>
+                    {new Date(entry.created_at).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </div>
+                  <div>By {entry.created_by}</div>
+                </div>
+              </div>
+
+              {/* Revert button (disabled if already active) */}
+              {!entry.is_active && (
+                <button
+                  onClick={() => {
+                    setRevertingVersion(entry.version);
+                    setRevertReason('');
+                    setRevertError(null);
+                  }}
+                  className={`flex items-center gap-1 px-3 py-1 rounded text-sm transition-colors ${
+                    revertingVersion === entry.version
+                      ? theme === 'dark'
+                        ? 'bg-gray-800 text-gray-400'
+                        : 'bg-gray-200 text-gray-600'
+                      : theme === 'dark'
+                        ? 'text-orange-400 hover:bg-gray-800'
+                        : 'text-orange-600 hover:bg-gray-100'
+                  }`}
+                >
+                  <RotateCcw className="w-4 h-4" />
+                  Revert
+                </button>
+              )}
+            </div>
+
+            {/* Reason */}
+            <p className={`text-sm mb-4 ${
+              theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+            }`}>
+              {entry.reason}
+            </p>
+
+            {/* Changes in this version */}
+            {Object.keys(entry.overrides).length > 0 && (
+              <div className={`text-xs mb-4 space-y-1 font-mono ${
+                theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+              }`}>
+                <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-500'}>
+                  Changes:
+                </div>
+                {Object.entries(entry.overrides).map(([path, value]) => (
+                  <div key={path}>
+                    {path}: <span className={theme === 'dark' ? 'text-gray-300' : 'text-gray-900'}>{String(value)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Revert form (shows when reverting this version) */}
+            {revertingVersion === entry.version && (
+              <div className={`rounded border-t pt-3 mt-3 ${
+                theme === 'dark' ? 'border-gray-700' : 'border-gray-300'
+              }`}>
+                <label className={`block text-xs font-medium mb-2 ${
+                  theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                }`}>
+                  Reason for reverting <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={revertReason}
+                  onChange={(e) => setRevertReason(e.target.value)}
+                  placeholder="Why are you reverting to this version?"
+                  className={`w-full px-2 py-1 rounded border text-xs ${
+                    theme === 'dark'
+                      ? 'border-gray-700 bg-gray-800 text-white'
+                      : 'border-gray-300 bg-white text-gray-900'
+                  }`}
+                  rows={2}
+                />
+
+                <div className="flex gap-2 mt-3">
+                  <button
+                    onClick={() => handleRevert(entry.version)}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                      theme === 'dark'
+                        ? 'bg-orange-600 text-white hover:bg-orange-700'
+                        : 'bg-orange-500 text-white hover:bg-orange-600'
+                    }`}
+                  >
+                    Confirm Revert
+                  </button>
+                  <button
+                    onClick={() => setRevertingVersion(null)}
+                    className={`px-3 py-1 rounded text-sm transition-colors ${
+                      theme === 'dark'
+                        ? 'text-gray-400 hover:bg-gray-800'
+                        : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StrategyDetail.tsx
+++ b/src/components/StrategyDetail.tsx
@@ -10,6 +10,8 @@ import { TradingActivity } from './TradingActivity';
 import { AlphaAttribution } from './AlphaAttribution';
 import { EditPositionModal } from './EditPositionModal';
 import { OverrideHistory } from './OverrideHistory';
+import { ConfigDashboard } from './ConfigDashboard';
+import { ConfigHistory } from './ConfigHistory';
 
 interface StrategyDetailProps {
   strategy: Strategy;
@@ -19,7 +21,7 @@ interface StrategyDetailProps {
 
 export function StrategyDetail({ strategy, onBack, onRefresh }: StrategyDetailProps) {
   const [selectedPeriod, setSelectedPeriod] = useState('1M');
-  const [selectedTab, setSelectedTab] = useState<'positions' | 'analysis' | 'activity' | 'history'>('positions');
+  const [selectedTab, setSelectedTab] = useState<'positions' | 'analysis' | 'activity' | 'history' | 'config'>('positions');
   const [editing, setEditing] = useState<{ symbol: string | null } | null>(null);
   const { theme } = useTheme();
   const { user } = useAuth();
@@ -241,20 +243,36 @@ export function StrategyDetail({ strategy, onBack, onRefresh }: StrategyDetailPr
             )}
           </button>
           {canEdit && (
-            <button
-              onClick={() => setSelectedTab('history')}
-              className={`pb-3 px-1 transition-colors relative ${selectedTab === 'history'
-                ? 'text-orange-500'
-                : theme === 'dark'
-                  ? 'text-gray-400 hover:text-white'
-                  : 'text-gray-500 hover:text-gray-900'
-                }`}
-            >
-              History
-              {selectedTab === 'history' && (
-                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
-              )}
-            </button>
+            <>
+              <button
+                onClick={() => setSelectedTab('history')}
+                className={`pb-3 px-1 transition-colors relative ${selectedTab === 'history'
+                  ? 'text-orange-500'
+                  : theme === 'dark'
+                    ? 'text-gray-400 hover:text-white'
+                    : 'text-gray-500 hover:text-gray-900'
+                  }`}
+              >
+                History
+                {selectedTab === 'history' && (
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
+                )}
+              </button>
+              <button
+                onClick={() => setSelectedTab('config')}
+                className={`pb-3 px-1 transition-colors relative ${selectedTab === 'config'
+                  ? 'text-orange-500'
+                  : theme === 'dark'
+                    ? 'text-gray-400 hover:text-white'
+                    : 'text-gray-500 hover:text-gray-900'
+                  }`}
+              >
+                Config
+                {selectedTab === 'config' && (
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
+                )}
+              </button>
+            </>
           )}
         </div>
 
@@ -292,6 +310,22 @@ export function StrategyDetail({ strategy, onBack, onRefresh }: StrategyDetailPr
 
       {selectedTab === 'history' && (
         <OverrideHistory strategyId={strategy.id} />
+      )}
+
+      {selectedTab === 'config' && (
+        <div className="grid gap-8 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <ConfigDashboard strategyId={strategy.id} />
+          </div>
+          <div>
+            <h3 className={`text-sm font-semibold uppercase tracking-wider mb-4 ${
+              theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+            }`}>
+              Audit Trail
+            </h3>
+            <ConfigHistory strategyId={strategy.id} />
+          </div>
+        </div>
       )}
 
       {/* Edit Position Modal */}

--- a/src/lib/configEdit.test.ts
+++ b/src/lib/configEdit.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Pure logic for config form editing—no React, no async.
+ * Tests run before implementation to catch design issues.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  flattenConfig,
+  mergeOverrides,
+  buildOverridePayload,
+  coerceValue,
+  canSubmitConfig,
+  type FlatConfigField,
+} from './configEdit';
+
+// Real effective config from the spec
+const EXAMPLE_EFFECTIVE = {
+  execution: { commission_rate: 0.0005, position_limit_live: 500, slippage_bps: 1 },
+  optimization: { buffer_size_factor: 0.01, cost_penalty_scalar: 50, tau: 1, use_buffering: true },
+  risk: { confidence_level: 0.99, lookback_period: 252, max_correlation: 0.85 },
+  strategy_defaults: { carver_buffer_floor: 0.5, max_strategy_allocation: 1, min_strategy_allocation: 0.1 },
+};
+
+describe('flattenConfig', () => {
+  it('flattens a nested config object into a list of fields with types', () => {
+    const fields = flattenConfig(EXAMPLE_EFFECTIVE);
+
+    expect(fields).toHaveLength(13); // Count all leaf fields
+
+    // Each field must have section, key, path, value, type
+    fields.forEach(field => {
+      expect(field).toHaveProperty('section');
+      expect(field).toHaveProperty('key');
+      expect(field).toHaveProperty('path');
+      expect(field).toHaveProperty('value');
+      expect(field).toHaveProperty('type');
+    });
+  });
+
+  it('correctly infers type as "number" for numeric values', () => {
+    const fields = flattenConfig(EXAMPLE_EFFECTIVE);
+    const slippageBpsField = fields.find(f => f.key === 'slippage_bps');
+
+    expect(slippageBpsField).toBeDefined();
+    expect(slippageBpsField?.type).toBe('number');
+    expect(slippageBpsField?.value).toBe(1);
+  });
+
+  it('correctly infers type as "boolean" for boolean values', () => {
+    const fields = flattenConfig(EXAMPLE_EFFECTIVE);
+    const useBufferingField = fields.find(f => f.key === 'use_buffering');
+
+    expect(useBufferingField).toBeDefined();
+    expect(useBufferingField?.type).toBe('boolean');
+    expect(useBufferingField?.value).toBe(true);
+  });
+
+  it('correctly infers type as "string" for string values', () => {
+    const testConfig = {
+      section: { name: 'test', value: 123 },
+    };
+    const fields = flattenConfig(testConfig);
+    const nameField = fields.find(f => f.key === 'name');
+
+    expect(nameField?.type).toBe('string');
+  });
+
+  it('marks nested objects/arrays as unsupported', () => {
+    const testConfig = {
+      good: { value: 1 },
+      bad: { nested: { deep: true } },
+    };
+    const fields = flattenConfig(testConfig);
+    const badField = fields.find(f => f.key === 'nested');
+
+    expect(badField?.type).toBe('unsupported');
+  });
+
+  it('marks arrays as unsupported', () => {
+    const testConfig = {
+      section: { items: [1, 2, 3] },
+    };
+    const fields = flattenConfig(testConfig);
+    const itemsField = fields.find(f => f.key === 'items');
+
+    expect(itemsField?.type).toBe('unsupported');
+  });
+
+  it('constructs correct dotted paths for nested keys', () => {
+    const fields = flattenConfig(EXAMPLE_EFFECTIVE);
+    const slippageField = fields.find(f => f.key === 'slippage_bps');
+
+    expect(slippageField?.path).toBe('execution.slippage_bps');
+  });
+
+  it('preserves section names for easy grouping', () => {
+    const fields = flattenConfig(EXAMPLE_EFFECTIVE);
+    const executionFields = fields.filter(f => f.section === 'execution');
+
+    expect(executionFields).toHaveLength(3);
+  });
+});
+
+describe('mergeOverrides', () => {
+  it('returns running=pending when no override exists', () => {
+    const result = mergeOverrides(EXAMPLE_EFFECTIVE, null);
+    const slippage = result['execution.slippage_bps'];
+
+    expect(slippage.running).toBe(1);
+    expect(slippage.pending).toBe(1);
+    expect(slippage.isOverridden).toBe(false);
+  });
+
+  it('shows different running vs pending when override exists', () => {
+    const overrides = { 'execution.slippage_bps': 3 };
+    const result = mergeOverrides(EXAMPLE_EFFECTIVE, overrides);
+    const slippage = result['execution.slippage_bps'];
+
+    expect(slippage.running).toBe(1);
+    expect(slippage.pending).toBe(3);
+    expect(slippage.isOverridden).toBe(true);
+  });
+
+  it('includes all effective fields even if not overridden', () => {
+    const result = mergeOverrides(EXAMPLE_EFFECTIVE, { 'execution.slippage_bps': 3 });
+
+    expect(result['execution.commission_rate']).toBeDefined();
+    expect(result['risk.confidence_level']).toBeDefined();
+  });
+
+  it('ignores overrides for paths not in effective', () => {
+    const overrides = { 'nonexistent.field': 99 };
+    const result = mergeOverrides(EXAMPLE_EFFECTIVE, overrides);
+
+    expect(result['nonexistent.field']).toBeUndefined();
+  });
+});
+
+describe('buildOverridePayload', () => {
+  it('excludes unchanged fields from the payload', () => {
+    const edits = { 'execution.commission_rate': 0.0005 }; // unchanged
+    const payload = buildOverridePayload(edits, EXAMPLE_EFFECTIVE);
+
+    expect(payload.execution).toBeUndefined();
+  });
+
+  it('includes only changed fields in the payload', () => {
+    const edits = {
+      'execution.slippage_bps': 3, // changed from 1
+      'execution.commission_rate': 0.0005, // unchanged
+    };
+    const payload = buildOverridePayload(edits, EXAMPLE_EFFECTIVE);
+
+    expect(payload.execution.slippage_bps).toBe(3);
+    expect(payload.execution.commission_rate).toBeUndefined();
+  });
+
+  it('nests changes by section', () => {
+    const edits = {
+      'execution.slippage_bps': 3,
+      'risk.confidence_level': 0.95,
+    };
+    const payload = buildOverridePayload(edits, EXAMPLE_EFFECTIVE);
+
+    expect(payload.execution).toBeDefined();
+    expect(payload.risk).toBeDefined();
+    expect(Object.keys(payload).length).toBe(2); // Only two sections changed
+  });
+
+  it('returns an empty object if no fields changed', () => {
+    const edits = {
+      'execution.commission_rate': 0.0005,
+      'execution.position_limit_live': 500,
+    };
+    const payload = buildOverridePayload(edits, EXAMPLE_EFFECTIVE);
+
+    expect(Object.keys(payload).length).toBe(0);
+  });
+
+  it('correctly nests multiple changes within a section', () => {
+    const edits = {
+      'execution.slippage_bps': 5,
+      'execution.position_limit_live': 1000,
+    };
+    const payload = buildOverridePayload(edits, EXAMPLE_EFFECTIVE);
+
+    expect(payload.execution.slippage_bps).toBe(5);
+    expect(payload.execution.position_limit_live).toBe(1000);
+  });
+});
+
+describe('coerceValue', () => {
+  it('parses a numeric string into a number when type is "number"', () => {
+    const result = coerceValue('42', 'number');
+    expect(result).toBe(42);
+  });
+
+  it('parses a decimal string into a number', () => {
+    const result = coerceValue('1.5', 'number');
+    expect(result).toBe(1.5);
+  });
+
+  it('returns undefined when a non-numeric string is parsed as number', () => {
+    const result = coerceValue('not a number', 'number');
+    expect(result).toBeUndefined();
+  });
+
+  it('parses "true" and "false" strings as booleans', () => {
+    expect(coerceValue('true', 'boolean')).toBe(true);
+    expect(coerceValue('false', 'boolean')).toBe(false);
+  });
+
+  it('returns undefined for invalid boolean strings', () => {
+    const result = coerceValue('yes', 'boolean');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns the string as-is when type is "string"', () => {
+    const result = coerceValue('hello world', 'string');
+    expect(result).toBe('hello world');
+  });
+
+  it('returns undefined for unsupported types', () => {
+    const result = coerceValue('anything', 'unsupported');
+    expect(result).toBeUndefined();
+  });
+
+  it('handles negative numbers correctly', () => {
+    expect(coerceValue('-5', 'number')).toBe(-5);
+    expect(coerceValue('-1.5', 'number')).toBe(-1.5);
+  });
+
+  it('handles zero correctly', () => {
+    expect(coerceValue('0', 'number')).toBe(0);
+  });
+
+  it('handles empty string for numbers as invalid', () => {
+    expect(coerceValue('', 'number')).toBeUndefined();
+  });
+});
+
+describe('canSubmitConfig', () => {
+  it('returns false when reason is empty', () => {
+    const edits = { 'execution.slippage_bps': 3 };
+    expect(canSubmitConfig(edits, '')).toBe(false);
+  });
+
+  it('returns false when reason is only whitespace', () => {
+    const edits = { 'execution.slippage_bps': 3 };
+    expect(canSubmitConfig(edits, '   ')).toBe(false);
+  });
+
+  it('returns false when there are no changes', () => {
+    const edits = {};
+    expect(canSubmitConfig(edits, 'Testing config')).toBe(false);
+  });
+
+  it('returns false when any edit failed to coerce (has undefined value)', () => {
+    // Simulate a failed coerce: the edit map has been built with invalid values
+    // The actual validation would catch this, but here we check that edits with
+    // undefined are rejected
+    const edits = {
+      'execution.slippage_bps': 3,
+      'risk.confidence_level': undefined, // Failed coerce
+    };
+    expect(canSubmitConfig(edits as any, 'Testing config')).toBe(false);
+  });
+
+  it('returns true when reason is valid and edits exist', () => {
+    const edits = { 'execution.slippage_bps': 3 };
+    expect(canSubmitConfig(edits, 'Adjusting slippage for market conditions')).toBe(true);
+  });
+
+  it('returns true with minimal reason text', () => {
+    const edits = { 'execution.slippage_bps': 3 };
+    expect(canSubmitConfig(edits, 'test')).toBe(true);
+  });
+
+  it('returns true when multiple edits exist and reason is valid', () => {
+    const edits = {
+      'execution.slippage_bps': 3,
+      'risk.confidence_level': 0.95,
+    };
+    expect(canSubmitConfig(edits, 'Risk reduction pass')).toBe(true);
+  });
+});

--- a/src/lib/configEdit.ts
+++ b/src/lib/configEdit.ts
@@ -1,0 +1,174 @@
+/**
+ * Pure logic for config form editing—no React, no async.
+ *
+ * Key insight: the engine reloads config once per session, at start.
+ * So two different values exist: what's running (effective), and what's
+ * staged for the next session (active_overrides.overrides).
+ * The form must show both, unmistakably.
+ */
+
+export interface FlatConfigField {
+  section: string;
+  key: string;
+  path: string; // dotted: execution.slippage_bps
+  value: any;
+  type: 'number' | 'boolean' | 'string' | 'unsupported';
+}
+
+export interface MergedField {
+  running: any;
+  pending: any;
+  isOverridden: boolean;
+}
+
+/**
+ * Flatten nested config object into a list of editable fields.
+ * Each leaf becomes a {section, key, path, value, type}.
+ * Arrays and nested objects are marked unsupported (render read-only).
+ */
+export function flattenConfig(
+  effective: Record<string, Record<string, any>>,
+): FlatConfigField[] {
+  const fields: FlatConfigField[] = [];
+
+  for (const [section, sectionValue] of Object.entries(effective)) {
+    if (typeof sectionValue !== 'object' || sectionValue === null) continue;
+
+    for (const [key, value] of Object.entries(sectionValue)) {
+      const type = inferType(value);
+      const path = `${section}.${key}`;
+
+      fields.push({
+        section,
+        key,
+        path,
+        value,
+        type,
+      });
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Infer the type of a value. Returns 'unsupported' for arrays/nested objects.
+ */
+function inferType(value: any): 'number' | 'boolean' | 'string' | 'unsupported' {
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'string') return 'string';
+  if (Array.isArray(value)) return 'unsupported';
+  if (typeof value === 'object' && value !== null) return 'unsupported';
+  return 'unsupported';
+}
+
+/**
+ * Merge effective config with pending overrides.
+ * Return a map of path -> {running, pending, isOverridden}.
+ * This lets the UI show both values without recomputing.
+ */
+export function mergeOverrides(
+  effective: Record<string, Record<string, any>>,
+  overrides: Record<string, any> | null,
+): Record<string, MergedField> {
+  const result: Record<string, MergedField> = {};
+  const overridesMap = overrides || {};
+
+  for (const [section, sectionValue] of Object.entries(effective)) {
+    if (typeof sectionValue !== 'object' || sectionValue === null) continue;
+
+    for (const [key, runningValue] of Object.entries(sectionValue)) {
+      const path = `${section}.${key}`;
+      const pendingValue = overridesMap[path] !== undefined ? overridesMap[path] : runningValue;
+
+      result[path] = {
+        running: runningValue,
+        pending: pendingValue,
+        isOverridden: overridesMap[path] !== undefined,
+      };
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Build nested override payload from edits.
+ * Only include paths whose value actually changed from effective.
+ * Sending unchanged values back would create meaningless audit entries.
+ */
+export function buildOverridePayload(
+  edits: Record<string, any>,
+  effective: Record<string, Record<string, any>>,
+): Record<string, Record<string, any>> {
+  const payload: Record<string, Record<string, any>> = {};
+
+  for (const [path, newValue] of Object.entries(edits)) {
+    if (newValue === undefined) continue; // Skip coerce failures
+
+    const [section, key] = path.split('.');
+    const oldValue = effective[section]?.[key];
+
+    // Only include if actually changed
+    if (newValue !== oldValue) {
+      if (!payload[section]) {
+        payload[section] = {};
+      }
+      payload[section][key] = newValue;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Coerce an input string to the declared type.
+ * Return undefined for invalid input so the caller can block submit.
+ */
+export function coerceValue(raw: string, type: 'number' | 'boolean' | 'string' | 'unsupported'): any {
+  if (type === 'number') {
+    const n = parseFloat(raw);
+    return isNaN(n) ? undefined : n;
+  }
+
+  if (type === 'boolean') {
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+    return undefined;
+  }
+
+  if (type === 'string') {
+    return raw;
+  }
+
+  // unsupported
+  return undefined;
+}
+
+/**
+ * Guard submit based on form state.
+ * Returns false if reason is empty/whitespace, no changes, or any coerce failed.
+ */
+export function canSubmitConfig(
+  edits: Record<string, any>,
+  reason: string,
+): boolean {
+  // Reason must be non-empty and non-whitespace
+  if (!reason || !reason.trim()) {
+    return false;
+  }
+
+  // Must have at least one change
+  const changes = Object.values(edits).filter(v => v !== undefined);
+  if (changes.length === 0) {
+    return false;
+  }
+
+  // No coerce failures (values must not be undefined)
+  if (Object.values(edits).includes(undefined)) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/services/portfolioApi.ts
+++ b/src/services/portfolioApi.ts
@@ -33,6 +33,59 @@ export type OverrideRecord = {
 };
 
 /**
+ * Config response from GET /portfolio/config/<strategy_id>
+ * 'effective': what the engine is currently running
+ * 'active_overrides': what is staged for the next session (or null)
+ * 'version': audit table sequence number (or null)
+ */
+export type ConfigResponse = {
+  effective: Record<string, Record<string, number | boolean | string>>;
+  active_overrides: {
+    id: number;
+    version: number;
+    overrides: Record<string, any>;
+    reason: string;
+    created_by: string;
+    created_at: string;
+  } | null;
+  version: number | null;
+};
+
+/**
+ * Config history entry from GET /portfolio/config/<strategy_id>/history
+ * Each version in the audit table, newest first
+ */
+export type ConfigHistoryEntry = {
+  id: number;
+  version: number;
+  overrides: Record<string, any>;
+  reason: string;
+  created_by: string;
+  created_at: string;
+  is_active: boolean;
+};
+
+export type ConfigHistoryResponse = {
+  versions: ConfigHistoryEntry[];
+};
+
+/**
+ * Request body for POST /portfolio/config/<strategy_id>
+ */
+export type UpdateConfigInput = {
+  overrides: Record<string, Record<string, any>>;
+  reason: string;
+};
+
+/**
+ * Request body for POST /portfolio/config/<strategy_id>/activate
+ */
+export type ActivateConfigInput = {
+  version: number;
+  reason: string;
+};
+
+/**
  * The backend answered 409 WITH a risk_check: the write is allowed, but only
  * after the user explicitly acknowledges the breach. Distinct from a plain
  * rejection, which carries no risk_check and cannot be overridden at all.
@@ -402,5 +455,171 @@ export class PortfolioApiService {
     const response = await this.fetchWithAuth(url);
     const payload = await response.json();
     return payload.overrides ?? [];
+  }
+
+  /**
+   * Fetch config for a strategy: effective (running), active_overrides (pending),
+   * and version number for audit trail.
+   */
+  static async getConfig(strategyId: string): Promise<ConfigResponse> {
+    log('info', `getConfig(${strategyId}) called`);
+    const url = `${API_BASE_URL}/portfolio/config/${strategyId}`;
+    log('info', `Fetching config from: ${url}`);
+
+    const response = await this.fetchWithAuth(url);
+
+    // Handle 403 distinctly: user does not have permission to edit config
+    if (response.status === 403) {
+      log('warn', 'Config edit not permitted (403)');
+      throw new Error('You do not have permission to edit this strategy\'s configuration.');
+    }
+
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      throw new Error(payload.error ?? `Failed to fetch config (${response.status})`);
+    }
+
+    const data = await response.json();
+    log('info', 'Config fetched successfully', {
+      effectiveKeys: Object.keys(data.effective || {}).length,
+      hasActiveOverrides: !!data.active_overrides,
+      version: data.version,
+    });
+
+    return data as ConfigResponse;
+  }
+
+  /**
+   * Fetch config version history: audit trail of all config changes.
+   * Newest first; includes is_active flag for the currently staged version.
+   */
+  static async getConfigHistory(strategyId: string): Promise<ConfigHistoryResponse> {
+    log('info', `getConfigHistory(${strategyId}) called`);
+    const url = `${API_BASE_URL}/portfolio/config/${strategyId}/history`;
+    log('info', `Fetching config history from: ${url}`);
+
+    const response = await this.fetchWithAuth(url);
+
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      throw new Error(payload.error ?? `Failed to fetch config history (${response.status})`);
+    }
+
+    const data = await response.json();
+    log('info', 'Config history fetched', { versionCount: data.versions?.length || 0 });
+
+    return data as ConfigHistoryResponse;
+  }
+
+  /**
+   * Update strategy config: post new overrides to take effect at next session start.
+   * Returns 201 on success. Never sends unchanged values to avoid audit bloat.
+   */
+  static async updateConfig(
+    strategyId: string,
+    input: UpdateConfigInput,
+  ): Promise<{ id: number; version: number }> {
+    log('info', `updateConfig(${strategyId}) called`);
+    const token = this.getAuthToken();
+    if (!token) throw new Error('No authentication token found');
+
+    const url = `${API_BASE_URL}/portfolio/config/${strategyId}`;
+    log('info', `Posting config update to: ${url}`, { reason: input.reason });
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(input),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+
+    // Handle 401/422 token errors
+    if (response.status === 401 || response.status === 422) {
+      log('warn', `Token error (${response.status}) - clearing credentials and redirecting to login`);
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      window.location.href = '/login';
+      throw new Error('Session expired or invalid. Please log in again.');
+    }
+
+    // Handle 403: user does not have permission
+    if (response.status === 403) {
+      log('warn', 'Config update not permitted (403)');
+      throw new Error('You do not have permission to edit this strategy\'s configuration.');
+    }
+
+    // Handle 400: validation error (e.g., invalid parameter names, bad nesting)
+    if (response.status === 400) {
+      log('error', 'Config validation error (400)', payload);
+      throw new Error(payload.error ?? 'Invalid configuration: check parameter names and types.');
+    }
+
+    if (!response.ok) {
+      log('error', `Config update failed (${response.status})`, payload);
+      throw new Error(payload.error ?? `Request failed (${response.status})`);
+    }
+
+    log('info', 'Config updated successfully', payload);
+    return payload as { id: number; version: number };
+  }
+
+  /**
+   * Activate a specific config version from history: revert or jump to a prior snapshot.
+   * Takes effect at next session start. Returns 201 on success.
+   */
+  static async activateConfigVersion(
+    strategyId: string,
+    input: ActivateConfigInput,
+  ): Promise<{ version: number }> {
+    log('info', `activateConfigVersion(${strategyId}, v${input.version}) called`);
+    const token = this.getAuthToken();
+    if (!token) throw new Error('No authentication token found');
+
+    const url = `${API_BASE_URL}/portfolio/config/${strategyId}/activate`;
+    log('info', `Activating config version at: ${url}`, { version: input.version, reason: input.reason });
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(input),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+
+    // Handle 401/422 token errors
+    if (response.status === 401 || response.status === 422) {
+      log('warn', `Token error (${response.status}) - clearing credentials and redirecting to login`);
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      window.location.href = '/login';
+      throw new Error('Session expired or invalid. Please log in again.');
+    }
+
+    // Handle 403: user does not have permission
+    if (response.status === 403) {
+      log('warn', 'Config activation not permitted (403)');
+      throw new Error('You do not have permission to edit this strategy\'s configuration.');
+    }
+
+    // Handle 404: version not found
+    if (response.status === 404) {
+      log('error', 'Config version not found (404)', { version: input.version });
+      throw new Error('This config version does not exist or belongs to a different strategy.');
+    }
+
+    if (!response.ok) {
+      log('error', `Config activation failed (${response.status})`, payload);
+      throw new Error(payload.error ?? `Request failed (${response.status})`);
+    }
+
+    log('info', 'Config version activated successfully', payload);
+    return payload as { version: number };
   }
 }


### PR DESCRIPTION
The form. Completes F3 — QT adjusts trade-ngin's trading parameters in the browser instead of asking an engineer to edit JSON inside a container.

**Base branch is `feat/config-dashboard` (#33)**, the backend it consumes. Pairs with trade-ngin#60 on the engine side.

## The thing this UI exists to get right

The engine reloads config **once per session, at session start** — not immediately. So two values are always in play, and they genuinely differ. In the live test data `effective.execution.slippage_bps` is **1** while the staged override is **3**, because the engine hasn't restarted.

A form showing one number would be actively dangerous: QT changes a risk parameter, sees the new value, and trades believing it is live when it takes effect tomorrow morning.

So every overridden field shows **both** — `Running: 1` / `Pending: 3` — plus a banner whenever any pending change exists, stating that pending values apply at next session start. Deliberately not a tooltip. That distinction is the difference between a trader knowing a change is live and assuming it.

## Rendered from the engine, never from a list

The form is generated from the API's `effective` object. **There is no hardcoded parameter list anywhere in this PR.**

That is the whole point: `defaults.json` contains an entire `risk_defaults` section the engine never reads, whose values lose to hardcoded constants. A form that invented fields would hand QT knobs that do nothing. If a parameter isn't in `effective`, it doesn't render.

Nested arrays and objects (e.g. the `fdm` matrix) render **read-only** with a note, rather than as a broken input.

## What's included

- `src/lib/configEdit.ts` — pure logic, TDD'd: flatten, merge running-vs-pending, build payload, coerce, submit-gating
- `ConfigDashboard.tsx` — typed inputs by value type, diff summary, mandatory reason, 403 handled distinctly
- `ConfigHistory.tsx` — versions newest first with per-version changed paths and a Revert that requires its own reason
- A `config` tab in `StrategyDetail`, behind the same `canEdit` role gate as the position editor

When `effective` is absent the panel says the engine hasn't published its configuration yet, rather than rendering an empty form that would imply the engine has no parameters.

## Verification

**56 tests**, `npm run build` clean.

Two classic falsy-value traps were specifically probed, because they are exactly how a config form silently drops a change:
- toggling a boolean **to `false`** is submitted as a real change, not discarded as falsy
- setting a number **to `0`** is submitted as a real change

Both behave correctly. Unchanged fields are excluded from the payload entirely — resubmitting identical values would mint meaningless versions in an append-only audit table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)