### PR TITLE
Dev-mode login bypass via httpOnly cookie (DEV_MODE=1, local only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@
 # VITE_API_URL=https://api.yourdomain.com
 
 VITE_API_URL=http://localhost:5000
+
+# Development Auth Bypass (LOCAL ONLY)
+# When set to 1, the app auto-authenticates via the backend's /auth/dev-login
+# (which sets the same httpOnly cookie a real login would) and skips the login
+# screen entirely. Requires DEV_MODE=1 on the backend too. Leave unset normally.
+# VITE_DEV_MODE=1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,19 @@ FLASK_ENV=production
 # NEVER set FLASK_DEBUG=true in production - it exposes remote code execution vulnerability
 FLASK_DEBUG=False
 
+# Development Auth Bypass (LOCAL DEVELOPMENT ONLY)
+# When DEV_MODE=1 and FLASK_ENV is not 'production', POST /auth/dev-login sets an
+# httpOnly auth cookie for a synthetic dev user with NO credentials, letting the
+# frontend skip the login screen. Force-DISABLED whenever FLASK_ENV=production;
+# never set it in a deployed environment. Leave at 0 (or unset) in normal use.
+DEV_MODE=0
+# Identity baked into the dev session. Point DEV_USER_ID at a real auth.users id
+# if you need writes (position/config edits) to satisfy foreign keys; reads work
+# with any value. Role defaults to admin so the whole dashboard is usable.
+DEV_USER_ID=1
+DEV_USER_EMAIL=dev@algolens.local
+DEV_USER_ROLE=admin
+
 # Port Configuration
 PORT=5000
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -74,6 +74,19 @@ app.logger.addHandler(console_handler)
 app.logger.setLevel(logging.DEBUG)
 app.logger.info("AlgoLens backend startup")
 
+# Loudly surface the dev auth bypass so it can never be a silent surprise.
+if os.getenv("DEV_MODE") == "1":
+    if IS_PRODUCTION:
+        app.logger.warning(
+            "[DEV_MODE] DEV_MODE=1 is set but FLASK_ENV=production -- the "
+            "/auth/dev-login bypass is DISABLED for safety."
+        )
+    else:
+        app.logger.warning(
+            "[DEV_MODE] DEV_MODE=1 active -- POST /auth/dev-login will establish "
+            "a session WITHOUT credentials. Local development only."
+        )
+
 
 # Log all requests
 @app.before_request

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Blueprint, request, jsonify, current_app
 from flask_jwt_extended import (
     create_access_token,
@@ -11,6 +13,19 @@ from database import execute_query
 from extensions import limiter
 
 auth_bp = Blueprint("auth", __name__)
+
+
+def _dev_mode_enabled():
+    """Whether the local dev auth bypass is active.
+
+    True only when DEV_MODE=1 *and* we are not running as production. The
+    FLASK_ENV guard is deliberate defence-in-depth: even if DEV_MODE=1 leaks
+    into a deployed .env, the bypass stays off. Read at call time (not import
+    time) so it is togglable in tests and per-request.
+    """
+    if os.getenv("FLASK_ENV", "production").lower() == "production":
+        return False
+    return os.getenv("DEV_MODE") == "1"
 
 # Minimum password length enforced server-side (the client mirrors this in
 # RegisterView.tsx, but the server is the authority).
@@ -135,6 +150,56 @@ def logout():
     or jwt_required is imposed here."""
     resp = jsonify({"message": "Logged out"})
     unset_jwt_cookies(resp)
+    return resp, 200
+
+
+@auth_bp.route("/dev-login", methods=["POST"])
+def dev_login():
+    """Establish a dev session without credentials, for local development only.
+
+    Mirrors /login's cookie delivery: it mints a real signed JWT for a synthetic
+    dev user and sets it as the httpOnly access cookie (plus the CSRF companion),
+    so every @jwt_required / @internal_only route works unchanged. The token is
+    never returned in the body -- same reasoning as /login.
+
+    Returns 404 unless DEV_MODE=1 and FLASK_ENV is not production, so the route
+    is invisible in a deployed build. Identity/role come from env (DEV_USER_ID /
+    DEV_USER_EMAIL / DEV_USER_ROLE, default admin); point DEV_USER_ID at a real
+    auth.users id if you need writes to satisfy foreign keys.
+    """
+    if not _dev_mode_enabled():
+        # Behave as if the route does not exist when the bypass is off.
+        return jsonify({"error": "Not found"}), 404
+
+    try:
+        dev_user_id = int(os.getenv("DEV_USER_ID", "1"))
+    except ValueError:
+        current_app.logger.warning(
+            "[DEV_MODE] DEV_USER_ID is not an integer; falling back to 1"
+        )
+        dev_user_id = 1
+
+    dev_user = {
+        "id": dev_user_id,
+        "email": os.getenv("DEV_USER_EMAIL", "dev@algolens.local"),
+        "first_name": "Dev",
+        "last_name": "User",
+        "role": os.getenv("DEV_USER_ROLE", "admin"),
+    }
+
+    access_token = create_access_token(
+        identity=str(dev_user["id"]),
+        additional_claims={"email": dev_user["email"], "role": dev_user["role"]},
+    )
+
+    current_app.logger.warning(
+        "[DEV_MODE] Issued dev-login cookie for %s (role=%s) -- auth is bypassed; "
+        "never enable this in production",
+        dev_user["email"], dev_user["role"],
+    )
+
+    resp = jsonify({"user": dev_user})
+    set_access_cookies(resp, access_token)
     return resp, 200
 
 

--- a/backend/tests/test_dev_login.py
+++ b/backend/tests/test_dev_login.py
@@ -1,0 +1,73 @@
+"""Tests for the DEV_MODE cookie dev-login (POST /auth/dev-login).
+
+The bypass must be off by default, force-disabled in production even if the flag
+is set, and -- when enabled -- must deliver the session as an httpOnly cookie
+(never a body token) that the existing @jwt_required routes accept unchanged.
+"""
+
+import pytest
+from app import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.app_context():
+        yield app.test_client()
+
+
+def test_dev_login_disabled_by_default_returns_404(client, monkeypatch):
+    monkeypatch.delenv("DEV_MODE", raising=False)
+    assert client.post("/auth/dev-login").status_code == 404
+
+
+def test_dev_login_refused_in_production_even_if_flag_set(client, monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.setenv("FLASK_ENV", "production")
+    assert client.post("/auth/dev-login").status_code == 404
+
+
+def test_dev_login_sets_httponly_cookie_and_no_body_token(client, monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    resp = client.post("/auth/dev-login")
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    # The token must be delivered as a cookie, never in the body.
+    assert "token" not in body, f"token leaked into body: {body}"
+    assert body["user"]["role"] == "admin"
+
+    set_cookies = resp.headers.getlist("Set-Cookie")
+    access = [c for c in set_cookies if c.startswith("access_token_cookie=")]
+    assert access, f"expected access_token_cookie; got {set_cookies}"
+    assert "HttpOnly" in access[0], f"access cookie must be HttpOnly: {access[0]}"
+    csrf = [c for c in set_cookies if c.startswith("csrf_access_token=")]
+    assert csrf, f"expected csrf_access_token; got {set_cookies}"
+    assert "HttpOnly" not in csrf[0], "CSRF cookie must be readable by JS"
+
+
+def test_dev_login_respects_env_overrides(client, monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    monkeypatch.setenv("DEV_USER_ID", "42")
+    monkeypatch.setenv("DEV_USER_EMAIL", "someone@algolens.local")
+    monkeypatch.setenv("DEV_USER_ROLE", "general_member")
+    body = client.post("/auth/dev-login").get_json()
+    assert body["user"]["id"] == 42
+    assert body["user"]["email"] == "someone@algolens.local"
+    assert body["user"]["role"] == "general_member"
+
+
+def test_dev_cookie_passes_the_auth_gate(client, monkeypatch):
+    """The cookie dev-login sets must satisfy @jwt_required on a protected GET.
+
+    /portfolio/strategies is @jwt_required. A GET is a safe method, so no CSRF
+    header is needed -- the cookie alone must get us past auth (not 401/422). It
+    may still be 500 if no DB is configured, but that is behind the auth gate.
+    """
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    client.post("/auth/dev-login")  # sets the cookie on the client's jar
+    resp = client.get("/portfolio/strategies")
+    assert resp.status_code not in (401, 422)

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,7 +21,12 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 // Get API URL from environment variable or default to localhost
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
-console.log('[AuthContext] Initialized with API_URL:', API_URL);
+// When set, skip the login screen and auto-authenticate via the backend's
+// dev-login endpoint (which sets the same httpOnly cookie as a real login).
+// Local development only; requires DEV_MODE=1 on the backend.
+const DEV_MODE = import.meta.env.VITE_DEV_MODE === '1';
+
+console.log('[AuthContext] Initialized with API_URL:', API_URL, 'DEV_MODE:', DEV_MODE);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -48,6 +53,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           if (!cancelled) {
             console.log('[AuthContext] Session restored for user:', data.user?.email);
             setUser(data.user);
+          }
+        } else if (DEV_MODE) {
+          // No active session, but dev mode is on: establish one without
+          // credentials via the backend dev-login (which sets the same httpOnly
+          // cookie a real login would), so the login screen is skipped entirely.
+          console.log('[AuthContext] DEV_MODE on -- requesting dev session');
+          const devResp = await fetch(`${API_URL}/auth/dev-login`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+          });
+          if (devResp.ok) {
+            const devData = await devResp.json();
+            if (!cancelled) {
+              console.log('[AuthContext] Dev session established for', devData.user?.email);
+              setUser(devData.user);
+            }
+          } else {
+            console.warn(
+              `[AuthContext] dev-login unavailable (status ${devResp.status}) -- ` +
+              'is DEV_MODE=1 set on the backend? Showing login screen.'
+            );
           }
         } else {
           // 401 here just means "not logged in" -- expected, not an error.


### PR DESCRIPTION
Lets local development skip the login screen. Reworked to fit the **httpOnly-cookie auth model** from #59 (was previously a body-token/localStorage approach).

## How
- **Backend** (`POST /auth/dev-login`): mirrors `/login` — mints a real JWT for a synthetic dev user and delivers it via `set_access_cookies` (httpOnly access cookie + CSRF companion). **No body token.** Every `@jwt_required` / `@internal_only` route works unchanged.
- **Frontend** (`AuthContext`): in the cookie-based session-restore flow, when `/auth/verify` reports no session and `VITE_DEV_MODE=1`, it calls dev-login (`credentials: 'include'`, which sets the cookie) and drops straight into the dashboard. No `localStorage`.

## Safety guardrails
- **Off by default**; route 404s unless `DEV_MODE=1`.
- **Force-disabled in production** — `FLASK_ENV=production` blocks it even if `DEV_MODE=1` leaks into a deployed `.env`.
- Loud WARNING on startup + on every issued session.

## Validation
- Backend cookie behavior verified (7/7 via Flask test client): 404 off, 404 in prod, 200 + httpOnly cookie + CSRF cookie + no body token when on. Committed `test_dev_login.py` runs the same in CI.
- `vite build` compiles.

Supersedes the pre-cookie version of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)