### PR TITLE
Strategy Builder: use real equity-curve data instead of Math.random (fixes #56)

### DIFF
--- a/src/components/strategy-builder/AdvancedSections.tsx
+++ b/src/components/strategy-builder/AdvancedSections.tsx
@@ -29,42 +29,52 @@ export function AdvancedSections({ metrics, theme, expanded, onToggle }: Advance
       {expanded.diversification && (
         <div className={`p-4 border ${theme === 'dark' ? 'bg-gray-950 border-gray-800' : 'bg-gray-50 border-gray-200'
           }`}>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr>
-                  <th className="p-1 text-left"></th>
-                  {metrics.advancedMetrics.topHoldings.map(h => (
-                    <th key={h.symbol} className="p-1 text-center font-mono">{h.symbol}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {metrics.advancedMetrics.correlationMatrix.map((row, i) => (
-                  <tr key={i}>
-                    <td className="p-1 font-mono">{metrics.advancedMetrics.topHoldings[i].symbol}</td>
-                    {row.map((corr, j) => (
-                      <td key={j} className="p-1">
-                        <div
-                          className="w-12 h-8 flex items-center justify-center text-white text-xs font-mono"
-                          style={{
-                            backgroundColor: `rgba(${corr > 0.7 ? '239, 68, 68' : corr > 0.4 ? '251, 146, 60' : '34, 197, 94'
-                              }, ${Math.abs(corr) * 0.7 + 0.3})`
-                          }}
-                        >
-                          {corr.toFixed(2)}
-                        </div>
-                      </td>
+          {metrics.advancedMetrics.correlationMatrix.length === 0 ? (
+            <div className={`text-xs ${theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+              }`}>
+              Correlation data unavailable — a real correlation matrix needs per-symbol
+              price history, which the API does not expose yet (tracked in issue #56).
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr>
+                      <th className="p-1 text-left"></th>
+                      {metrics.advancedMetrics.topHoldings.map(h => (
+                        <th key={h.symbol} className="p-1 text-center font-mono">{h.symbol}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {metrics.advancedMetrics.correlationMatrix.map((row, i) => (
+                      <tr key={i}>
+                        <td className="p-1 font-mono">{metrics.advancedMetrics.topHoldings[i].symbol}</td>
+                        {row.map((corr, j) => (
+                          <td key={j} className="p-1">
+                            <div
+                              className="w-12 h-8 flex items-center justify-center text-white text-xs font-mono"
+                              style={{
+                                backgroundColor: `rgba(${corr > 0.7 ? '239, 68, 68' : corr > 0.4 ? '251, 146, 60' : '34, 197, 94'
+                                  }, ${Math.abs(corr) * 0.7 + 0.3})`
+                              }}
+                            >
+                              {corr.toFixed(2)}
+                            </div>
+                          </td>
+                        ))}
+                      </tr>
                     ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <div className={`text-xs mt-3 ${theme === 'dark' ? 'text-gray-600' : 'text-gray-400'
-            }`}>
-            ■ Green: Low correlation (0.3-0.4) • ■ Orange: Moderate (0.4-0.7) • ■ Red: High (0.7+)
-          </div>
+                  </tbody>
+                </table>
+              </div>
+              <div className={`text-xs mt-3 ${theme === 'dark' ? 'text-gray-600' : 'text-gray-400'
+                }`}>
+                ■ Green: Low correlation (0.3-0.4) • ■ Orange: Moderate (0.4-0.7) • ■ Red: High (0.7+)
+              </div>
+            </>
+          )}
         </div>
       )}
 

--- a/src/components/strategy-builder/computeCombinedMetrics.test.ts
+++ b/src/components/strategy-builder/computeCombinedMetrics.test.ts
@@ -118,17 +118,50 @@ describe('computeCombinedMetrics', () => {
     expect(es.pnl).toBe(800);
   });
 
-  it('builds a correlation matrix with a unit diagonal', () => {
+  it('does not fabricate a correlation matrix (unavailable without per-symbol history)', () => {
     const a = strategy({
       id: 'a',
       currentValue: 100000,
       positions: [pos('ES', 40000), pos('NQ', 35000), pos('CL', 25000)],
     });
     const out = computeCombinedMetrics([a], ['a']);
-    const m = out.advancedMetrics.correlationMatrix;
-    expect(m).toHaveLength(3);
-    for (let i = 0; i < m.length; i++) {
-      expect(m[i][i]).toBe(1);
-    }
+    // Correlation needs per-symbol price history the API doesn't expose (issue #56),
+    // so it's returned empty rather than as random values...
+    expect(out.advancedMetrics.correlationMatrix).toEqual([]);
+    // ...but the real top holdings it would describe are still populated.
+    expect(out.advancedMetrics.topHoldings.map(h => h.symbol)).toEqual(['ES', 'NQ', 'CL']);
+  });
+
+  it('builds combined performance and daily PnL from the real equity curves', () => {
+    const a = strategy({
+      id: 'a',
+      currentValue: 100000,
+      historicalData: [
+        { date: '2026-01-01', value: 100000 },
+        { date: '2026-01-02', value: 110000 },
+        { date: '2026-01-03', value: 105000 },
+      ],
+    });
+    const b = strategy({
+      id: 'b',
+      currentValue: 100000,
+      historicalData: [
+        { date: '2026-01-01', value: 100000 },
+        { date: '2026-01-02', value: 100000 },
+        { date: '2026-01-03', value: 130000 },
+      ],
+    });
+    const out = computeCombinedMetrics([a, b], ['a', 'b']);
+
+    // Combined equity by date is 200k -> 210k -> 235k; performance is % from the base.
+    expect(out.historicalPerformance.map(p => p.date)).toEqual([
+      '2026-01-01', '2026-01-02', '2026-01-03',
+    ]);
+    expect(out.historicalPerformance[0].return).toBeCloseTo(0, 6);
+    expect(out.historicalPerformance[1].return).toBeCloseTo(5, 6);    // 210/200 - 1
+    expect(out.historicalPerformance[2].return).toBeCloseTo(17.5, 6); // 235/200 - 1
+
+    // Daily PnL is the day-over-day dollar change of that combined curve.
+    expect(out.dailyPnL.map(p => p.pnl)).toEqual([0, 10000, 25000]);
   });
 });

--- a/src/components/strategy-builder/computeCombinedMetrics.ts
+++ b/src/components/strategy-builder/computeCombinedMetrics.ts
@@ -92,10 +92,11 @@ function emptyCombined(): CombinedMetrics {
  * Combine the selected strategies into the aggregate view model: totals, asset and
  * strategy allocations, weighted metrics, and advanced risk stats.
  *
- * NOTE: some series (historicalPerformance, dailyPnL, and the correlation matrix)
- * are simulated with Math.random() -- this preserves the original component's
- * behaviour exactly. It is intentionally kept non-deterministic here; the caller
- * memoizes on the selection so the values are stable per selection.
+ * historicalPerformance and dailyPnL are derived from the selected strategies' REAL
+ * equity curves (Strategy.historicalData) -- summed by date, then expressed as a
+ * cumulative % return and day-over-day dollar change respectively. The correlation
+ * matrix is left empty: a real one needs per-symbol price history the API does not
+ * expose yet (see issue #56). This function is deterministic given its inputs.
  */
 export function computeCombinedMetrics(
   strategies: Strategy[],
@@ -151,19 +152,24 @@ export function computeCombinedMetrics(
     percentage: (s.currentValue / totalValue) * 100
   }));
 
-  // Historical performance data (combined)
-  const historicalPerformance: { date: string; return: number }[] = [];
-  const today = new Date();
-  let cumulativeReturn = 0;
-  for (let i = 90; i >= 0; i--) {
-    const date = new Date(today);
-    date.setDate(date.getDate() - i);
-    cumulativeReturn += (Math.random() - 0.45) * 0.5; // Trend upward
-    historicalPerformance.push({
-      date: date.toISOString().split('T')[0],
-      return: cumulativeReturn
+  // Combined equity curve: sum each selected strategy's REAL historical equity by
+  // date, then express it as cumulative % return from the first (earliest) point.
+  // Reads the actual per-strategy equity curves instead of simulating a series.
+  const equityByDate = new Map<string, number>();
+  selected.forEach(s => {
+    s.historicalData.forEach(pt => {
+      equityByDate.set(pt.date, (equityByDate.get(pt.date) || 0) + pt.value);
     });
-  }
+  });
+  const combinedCurve = Array.from(equityByDate.entries())
+    .map(([date, value]) => ({ date, value }))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  const baseEquity = combinedCurve.length > 0 ? combinedCurve[0].value : 0;
+  const historicalPerformance = combinedCurve.map(pt => ({
+    date: pt.date,
+    return: baseEquity > 0 ? ((pt.value - baseEquity) / baseEquity) * 100 : 0
+  }));
 
   // Combine all finalized positions for PnL by symbol
   const symbolPnL: { [key: string]: number } = {};
@@ -178,18 +184,14 @@ export function computeCombinedMetrics(
     .sort((a, b) => a[1] - b[1])
     .map(([symbol, pnl]) => ({ symbol, pnl }));
 
-  // Generate daily PnL data (simulated)
-  const dailyPnL = [];
-  for (let i = 30; i >= 0; i--) {
-    const date = new Date(today);
-    date.setDate(date.getDate() - i);
-    const variance = Math.random() - 0.5;
-    const basePnl = returnPercent > 0 ? 200 : -200;
-    dailyPnL.push({
-      date: date.toISOString().split('T')[0],
-      pnl: basePnl + variance * 800
-    });
-  }
+  // Daily PnL: day-over-day change in the combined equity curve (real dollars),
+  // most recent 31 days. Derived from the same real curve, not simulated.
+  const dailyPnL = combinedCurve
+    .map((pt, i) => ({
+      date: pt.date,
+      pnl: i === 0 ? 0 : pt.value - combinedCurve[i - 1].value
+    }))
+    .slice(-31);
 
   // Weighted average metrics - MUST BE CALCULATED FIRST
   const weightedMetrics: StrategyMetrics = {
@@ -277,15 +279,12 @@ export function computeCombinedMetrics(
     sum + Math.pow(asset.percentage, 2), 0
   );
 
-  // Correlation Matrix (top 5 holdings)
+  // Correlation Matrix (top 5 holdings). A real correlation needs per-symbol price
+  // history, which the API does not expose today (we only have current positions and
+  // the portfolio-level equity curve). Rather than fabricate values with Math.random,
+  // leave it empty so the UI shows an honest "unavailable" state. See issue #56.
   const topHoldings = assetAllocation.slice(0, 5);
-  const correlationMatrix = topHoldings.map(asset1 =>
-    topHoldings.map(asset2 => {
-      if (asset1.symbol === asset2.symbol) return 1;
-      // Simulate correlations (in real app, calculate from historical prices)
-      return 0.3 + Math.random() * 0.5;
-    })
-  );
+  const correlationMatrix: number[][] = [];
 
   // Value at Risk (95% confidence, 1-day)
   const portfolioStdDev = (weightedMetrics.volatility / 100) * totalValue / Math.sqrt(252);


### PR DESCRIPTION
Fixes #56.

## Problem
`computeCombinedMetrics` fabricated three outputs with `Math.random()` **in the running app** (not just tests): the combined performance line, the daily PnL bars, and the correlation matrix. The real per-strategy equity curve was available (`Strategy.historicalData`) but ignored.

## Change
- **Combined performance line** → aggregate the selected strategies' real `historicalData` by date into a combined equity curve, expressed as cumulative % return from the first point.
- **Daily PnL** → day-over-day dollar change of that same real curve (last 31 days).
- **Sortino** → now derives from the real return series (no code change needed; it consumed `historicalPerformance`).
- **Correlation matrix** → genuinely not computable client-side (needs per-symbol price history the API doesn't expose). Returned **empty** instead of random; `AdvancedSections` now shows an honest "unavailable" note referencing #56.
- `computeCombinedMetrics` is now **deterministic** given its inputs.

## Still an assumption (not `Math.random`, called out for follow-up)
Information Ratio still uses a hardcoded 12.5% benchmark and a simulated tracking error (`volatility * 0.7`). Left as-is; flag if you want it addressed.

## Validation
- `npm test` — 9/9 pass locally (vitest 3), including a new test asserting combined performance (`0% → 5% → 17.5%`) and daily PnL (`[0, 10000, 25000]`) against known curves, plus the correlation test updated to assert the empty/unavailable behavior.
- `npx vite build` — compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)