### PR TITLE
Member-only Incubation tab (mock-capital strategy trials)

### DIFF
--- a/algolens-api/algolens/adapters/http/portfolio.py
+++ b/algolens-api/algolens/adapters/http/portfolio.py
@@ -1,17 +1,27 @@
 """Portfolio HTTP routes."""
 
+from datetime import datetime, timezone
+from functools import wraps
 import time
 
-from flask import Blueprint, current_app, jsonify
-from flask_jwt_extended import jwt_required
+from flask import Blueprint, current_app, jsonify, request
+from flask_jwt_extended import get_jwt, get_jwt_identity, jwt_required
 
 from algolens.adapters.serializers.portfolio import (
+    serialize_incubating_strategy_list,
+    serialize_incubation_performance,
     serialize_strategy_detail,
     serialize_strategy_list,
 )
+from algolens.application.portfolio.ports import IncubationError
 from algolens.application.portfolio.use_cases import (
+    GetIncubationPerformance,
     GetStrategyDetail,
+    ListIncubatingStrategies,
     ListStrategies,
+    PromoteToLive,
+    RetireStrategy,
+    StartIncubation,
     StrategyDataNotFound,
     StrategyNotFound,
 )
@@ -19,9 +29,43 @@ from algolens.infrastructure.config.dependencies import create_portfolio_depende
 
 portfolio_bp = Blueprint("portfolio", __name__)
 
+# Incubation is an internal member-only surface. Default-deny: an unrecognised
+# or absent role is refused, so new roles stay locked out until explicitly added.
+INTERNAL_ROLES = frozenset({"admin", "general_member"})
+
 
 def _portfolio_dependencies():
     return create_portfolio_dependencies()
+
+
+def internal_only(fn):
+    """Refuse anyone whose JWT role is not an internal one."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        role = get_jwt().get("role")
+        if role not in INTERNAL_ROLES:
+            current_app.logger.warning(
+                "Refused %s to %s: role %r is not internal",
+                request.method,
+                request.path,
+                role,
+            )
+            return jsonify({"error": "Insufficient permissions"}), 403
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def _request_user_id():
+    user_id = get_jwt_identity()
+    if user_id is None:
+        raise IncubationError("Invalid user identity in token")
+    return str(user_id)
+
+
+def _incubation_error_status(exc):
+    return 404 if "not found" in str(exc).lower() else 400
 
 
 @portfolio_bp.route("/strategy/<strategy_id>", methods=["GET"])
@@ -72,3 +116,136 @@ def get_all_strategies():
             "[STRATEGIES] Error fetching strategies: %s", str(exc), exc_info=True
         )
         return jsonify({"error": "Failed to fetch strategies"}), 500
+
+
+@portfolio_bp.route("/incubation", methods=["GET"])
+@jwt_required()
+@internal_only
+def get_incubation_strategies():
+    try:
+        _registry, reader = _portfolio_dependencies()
+        strategies = ListIncubatingStrategies(reader).execute(
+            datetime.now(timezone.utc)
+        )
+        return jsonify(serialize_incubating_strategy_list(strategies)), 200
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to fetch incubating strategies: %s", str(exc), exc_info=True
+        )
+        return jsonify({"error": "Failed to fetch incubating strategies"}), 500
+
+
+@portfolio_bp.route("/incubation/<strategy_id>/performance", methods=["GET"])
+@jwt_required()
+@internal_only
+def get_incubation_perf(strategy_id):
+    try:
+        _registry, reader = _portfolio_dependencies()
+        performance = GetIncubationPerformance(reader).execute(strategy_id)
+        return jsonify(serialize_incubation_performance(performance)), 200
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to fetch incubation performance for %s: %s",
+            strategy_id,
+            str(exc),
+            exc_info=True,
+        )
+        return jsonify({"error": "Failed to fetch incubation performance"}), 500
+
+
+@portfolio_bp.route("/incubation/<strategy_id>/start", methods=["POST"])
+@jwt_required()
+@internal_only
+def start_strategy_incubation(strategy_id):
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    if payload.get("mock_capital") is None:
+        return jsonify({"error": "Missing required field: mock_capital"}), 400
+    if payload.get("reason") is None or not str(payload.get("reason")).strip():
+        return jsonify({"error": "Missing required field: reason"}), 400
+
+    try:
+        mock_capital = float(payload["mock_capital"])
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid mock_capital: must be a positive number"}), 400
+
+    try:
+        _registry, reader = _portfolio_dependencies()
+        StartIncubation(reader).execute(
+            strategy_id=strategy_id,
+            mock_capital=mock_capital,
+            reason=str(payload["reason"]),
+            user_id=_request_user_id(),
+        )
+        current_app.logger.info("Started incubation for strategy %s", strategy_id)
+        return jsonify({"message": "Incubation started"}), 201
+    except IncubationError as exc:
+        return jsonify({"error": str(exc)}), _incubation_error_status(exc)
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to start incubation for %s: %s",
+            strategy_id,
+            str(exc),
+            exc_info=True,
+        )
+        return jsonify({"error": "Failed to start incubation"}), 500
+
+
+@portfolio_bp.route("/incubation/<strategy_id>/promote", methods=["POST"])
+@jwt_required()
+@internal_only
+def promote_strategy_to_live(strategy_id):
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    if payload.get("reason") is None or not str(payload.get("reason")).strip():
+        return jsonify({"error": "Missing required field: reason"}), 400
+
+    try:
+        _registry, reader = _portfolio_dependencies()
+        PromoteToLive(reader).execute(
+            strategy_id=strategy_id,
+            reason=str(payload["reason"]),
+            user_id=_request_user_id(),
+        )
+        current_app.logger.info("Promoted strategy %s to live", strategy_id)
+        return jsonify({"message": "Strategy promoted to live"}), 200
+    except IncubationError as exc:
+        return jsonify({"error": str(exc)}), _incubation_error_status(exc)
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to promote %s: %s", strategy_id, str(exc), exc_info=True
+        )
+        return jsonify({"error": "Failed to promote strategy"}), 500
+
+
+@portfolio_bp.route("/incubation/<strategy_id>/retire", methods=["POST"])
+@jwt_required()
+@internal_only
+def retire_strategy(strategy_id):
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    if payload.get("reason") is None or not str(payload.get("reason")).strip():
+        return jsonify({"error": "Missing required field: reason"}), 400
+
+    try:
+        _registry, reader = _portfolio_dependencies()
+        RetireStrategy(reader).execute(
+            strategy_id=strategy_id,
+            reason=str(payload["reason"]),
+            user_id=_request_user_id(),
+        )
+        current_app.logger.info("Retired strategy %s", strategy_id)
+        return jsonify({"message": "Strategy retired"}), 200
+    except IncubationError as exc:
+        return jsonify({"error": str(exc)}), _incubation_error_status(exc)
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to retire %s: %s", strategy_id, str(exc), exc_info=True
+        )
+        return jsonify({"error": "Failed to retire strategy"}), 500

--- a/algolens-api/algolens/adapters/serializers/portfolio.py
+++ b/algolens-api/algolens/adapters/serializers/portfolio.py
@@ -1,9 +1,61 @@
 """Portfolio HTTP serializers."""
 
 
+def _isoformat(value):
+    return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+def _float_or_none(value):
+    return float(value) if value is not None else None
+
+
 def serialize_strategy_detail(strategy):
     return strategy
 
 
 def serialize_strategy_list(strategies):
     return {"strategies": strategies}
+
+
+def serialize_incubating_strategy(strategy):
+    return {
+        "id": strategy["id"],
+        "strategy_type": strategy["strategy_type"],
+        "portfolio_id": strategy["portfolio_id"],
+        "name": strategy["name"],
+        "description": strategy.get("description") or "",
+        "mock_capital": _float_or_none(strategy.get("mock_capital")),
+        "incubation_started_at": _isoformat(strategy.get("incubation_started_at")),
+        "days_elapsed": strategy["days_elapsed"],
+        "window_days": strategy["window_days"],
+        "progress": strategy["progress"],
+    }
+
+
+def serialize_incubating_strategy_list(strategies):
+    return {
+        "incubating_strategies": [
+            serialize_incubating_strategy(strategy) for strategy in strategies
+        ]
+    }
+
+
+def serialize_incubation_performance(performance):
+    return {
+        "positions": [
+            {
+                "date": _isoformat(position.get("date")),
+                "symbol": position.get("symbol"),
+                "quantity": _float_or_none(position.get("quantity")),
+                "entry_price": _float_or_none(position.get("entry_price")),
+            }
+            for position in performance["positions"]
+        ],
+        "equity_curve": [
+            {
+                "date": _isoformat(point.get("date")),
+                "equity": _float_or_none(point.get("equity")),
+            }
+            for point in performance["equity_curve"]
+        ],
+    }

--- a/algolens-api/algolens/application/portfolio/ports.py
+++ b/algolens-api/algolens/application/portfolio/ports.py
@@ -4,6 +4,12 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from algolens.application.shared.errors import ValidationError
+
+
+class IncubationError(ValidationError):
+    """Raised when an incubation operation violates lifecycle constraints."""
+
 
 @dataclass(frozen=True)
 class PortfolioDetailRows:
@@ -13,6 +19,12 @@ class PortfolioDetailRows:
     positions: Sequence[Mapping[str, Any]]
     executions: Sequence[Mapping[str, Any]]
     yesterday_positions: Sequence[Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class IncubationPerformanceRows:
+    positions: Sequence[Mapping[str, Any]]
+    equity_curve: Sequence[Mapping[str, Any]]
 
 
 class StrategyRegistryPort(Protocol):
@@ -30,4 +42,27 @@ class PortfolioReaderPort(Protocol):
         ...
 
     def fetch_detail_rows(self, strategy_type: str, portfolio_id: str) -> PortfolioDetailRows:
+        ...
+
+    def list_incubating_strategies(self) -> Sequence[Mapping[str, Any]]:
+        ...
+
+    def fetch_incubation_performance(
+        self, strategy_id: str
+    ) -> IncubationPerformanceRows:
+        ...
+
+    def start_incubation(
+        self,
+        strategy_id: str,
+        mock_capital: float,
+        reason: str,
+        user_id: str,
+    ) -> None:
+        ...
+
+    def promote_to_live(self, strategy_id: str, reason: str, user_id: str) -> None:
+        ...
+
+    def retire_strategy(self, strategy_id: str, reason: str, user_id: str) -> None:
         ...

--- a/algolens-api/algolens/application/portfolio/use_cases.py
+++ b/algolens-api/algolens/application/portfolio/use_cases.py
@@ -2,9 +2,12 @@
 
 import logging
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 from algolens.application.portfolio.ports import (
+    IncubationError,
+    IncubationPerformanceRows,
     PortfolioDetailRows,
     PortfolioReaderPort,
     StrategyRegistryPort,
@@ -20,6 +23,7 @@ from algolens.domain.portfolio.calculations import (
     transform_finalized,
     transform_positions,
 )
+from algolens.domain.portfolio.incubation import compute_incubation_window
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +132,45 @@ def build_strategy_summary(
     }
 
 
+def build_incubating_strategy(row: Mapping[str, Any], now: datetime) -> dict[str, Any]:
+    window = compute_incubation_window(row.get("incubation_started_at"), now)
+    return {
+        "id": row["id"],
+        "strategy_type": row["strategy_type"],
+        "portfolio_id": row["portfolio_id"],
+        "name": row["name"],
+        "description": row.get("description") or "",
+        "mock_capital": float(row["mock_capital"])
+        if row.get("mock_capital") is not None
+        else None,
+        "incubation_started_at": row.get("incubation_started_at"),
+        "days_elapsed": window.days_elapsed,
+        "window_days": window.window_days,
+        "progress": window.progress,
+    }
+
+
+def build_incubation_performance(
+    rows: IncubationPerformanceRows,
+) -> dict[str, list[Mapping[str, Any]]]:
+    return {
+        "positions": list(rows.positions),
+        "equity_curve": list(rows.equity_curve),
+    }
+
+
+def _require_reason(reason: str) -> str:
+    if not reason or not reason.strip():
+        raise IncubationError("reason must be non-empty")
+    return reason.strip()
+
+
+def _require_mock_capital(mock_capital: float) -> float:
+    if mock_capital <= 0:
+        raise IncubationError("mock_capital must be positive")
+    return mock_capital
+
+
 class GetStrategyDetail:
     def __init__(self, registry: StrategyRegistryPort, reader: PortfolioReaderPort):
         self.registry = registry
@@ -169,3 +212,66 @@ class ListStrategies:
             if summary:
                 strategies.append(summary)
         return strategies
+
+
+class ListIncubatingStrategies:
+    def __init__(self, reader: PortfolioReaderPort):
+        self.reader = reader
+
+    def execute(self, now: datetime) -> list[dict[str, Any]]:
+        return [
+            build_incubating_strategy(row, now)
+            for row in self.reader.list_incubating_strategies()
+        ]
+
+
+class GetIncubationPerformance:
+    def __init__(self, reader: PortfolioReaderPort):
+        self.reader = reader
+
+    def execute(self, strategy_id: str) -> dict[str, list[Mapping[str, Any]]]:
+        rows = self.reader.fetch_incubation_performance(strategy_id)
+        return build_incubation_performance(rows)
+
+
+class StartIncubation:
+    def __init__(self, reader: PortfolioReaderPort):
+        self.reader = reader
+
+    def execute(
+        self,
+        strategy_id: str,
+        mock_capital: float,
+        reason: str,
+        user_id: str,
+    ) -> None:
+        self.reader.start_incubation(
+            strategy_id=strategy_id,
+            mock_capital=_require_mock_capital(mock_capital),
+            reason=_require_reason(reason),
+            user_id=user_id,
+        )
+
+
+class PromoteToLive:
+    def __init__(self, reader: PortfolioReaderPort):
+        self.reader = reader
+
+    def execute(self, strategy_id: str, reason: str, user_id: str) -> None:
+        self.reader.promote_to_live(
+            strategy_id=strategy_id,
+            reason=_require_reason(reason),
+            user_id=user_id,
+        )
+
+
+class RetireStrategy:
+    def __init__(self, reader: PortfolioReaderPort):
+        self.reader = reader
+
+    def execute(self, strategy_id: str, reason: str, user_id: str) -> None:
+        self.reader.retire_strategy(
+            strategy_id=strategy_id,
+            reason=_require_reason(reason),
+            user_id=user_id,
+        )

--- a/algolens-api/algolens/domain/portfolio/incubation.py
+++ b/algolens-api/algolens/domain/portfolio/incubation.py
@@ -1,0 +1,52 @@
+"""Pure incubation lifecycle calculations."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+# Incubation window: strategies are observed for 3-4 months
+INCUBATION_WINDOW_DAYS = 120
+
+
+@dataclass(frozen=True)
+class IncubationWindow:
+    days_elapsed: int
+    window_days: int
+    progress: float
+
+
+def _align_datetime_awareness(started_at: datetime, now: datetime) -> datetime:
+    start_is_aware = started_at.tzinfo is not None and started_at.utcoffset() is not None
+    now_is_aware = now.tzinfo is not None and now.utcoffset() is not None
+    if start_is_aware and now_is_aware:
+        return now.astimezone(started_at.tzinfo)
+    if start_is_aware and not now_is_aware:
+        return now.replace(tzinfo=started_at.tzinfo)
+    if not start_is_aware and now_is_aware:
+        return now.replace(tzinfo=None)
+    return now
+
+
+def compute_incubation_window(
+    incubation_started_at: datetime | None,
+    now: datetime,
+    window_days: int = INCUBATION_WINDOW_DAYS,
+) -> IncubationWindow:
+    if incubation_started_at is None:
+        days_elapsed = 0
+    else:
+        comparable_now = _align_datetime_awareness(incubation_started_at, now)
+        # Clamped at zero. `incubation_started_at` is stamped by the DATABASE
+        # (`now()`), while this subtracts the APPLICATION host's clock, and the
+        # two are never perfectly in step. timedelta.days floors toward negative
+        # infinity, so a sub-second skew of the wrong sign turns into -1 -- which
+        # is what a strategy incubated moments ago actually reported. A negative
+        # elapsed count then renders as negative progress against the window.
+        days_elapsed = max(0, (comparable_now - incubation_started_at).days)
+
+    progress = min((days_elapsed / window_days) * 100, 100) if window_days > 0 else 0
+    return IncubationWindow(
+        days_elapsed=days_elapsed,
+        window_days=window_days,
+        progress=progress,
+    )

--- a/algolens-api/algolens/infrastructure/portfolio/repositories.py
+++ b/algolens-api/algolens/infrastructure/portfolio/repositories.py
@@ -2,7 +2,13 @@
 
 import time
 
-from algolens.application.portfolio.ports import PortfolioDetailRows
+import psycopg2
+
+from algolens.application.portfolio.ports import (
+    IncubationError,
+    IncubationPerformanceRows,
+    PortfolioDetailRows,
+)
 from algolens.domain.portfolio.streams import PORTFOLIO_STREAMS, PRIMARY_STREAM
 from algolens.infrastructure.db.postgres import get_db_connection
 
@@ -228,3 +234,213 @@ class PostgresPortfolioRepository:
             executions=executions,
             yesterday_positions=yesterday_positions,
         )
+
+    def list_incubating_strategies(self):
+        conn = self.connection_factory()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT id, strategy_type, portfolio_id, name, description,
+                           mock_capital, incubation_started_at
+                    FROM trading.strategy_registry
+                    WHERE lifecycle = 'incubating'
+                    ORDER BY incubation_started_at ASC NULLS LAST, sort_order ASC, id ASC
+                    """
+                )
+                return cursor.fetchall()
+        finally:
+            conn.close()
+
+    def _fetch_incubating_registry_row(self, cursor, strategy_id):
+        cursor.execute(
+            """
+            SELECT strategy_type, portfolio_id, incubation_started_at
+            FROM trading.strategy_registry
+            WHERE id = %s AND lifecycle = 'incubating'
+            """,
+            (strategy_id,),
+        )
+        return cursor.fetchone()
+
+    def fetch_incubation_performance(self, strategy_id):
+        conn = self.connection_factory()
+        try:
+            with conn.cursor() as cursor:
+                registry_row = self._fetch_incubating_registry_row(cursor, strategy_id)
+                if (
+                    registry_row is None
+                    or registry_row["incubation_started_at"] is None
+                ):
+                    return IncubationPerformanceRows(positions=[], equity_curve=[])
+
+                strategy_type = registry_row["strategy_type"]
+                portfolio_id = registry_row["portfolio_id"]
+                incubation_start = registry_row["incubation_started_at"]
+
+                cursor.execute(
+                    """
+                    SELECT updated_at AS date, symbol, quantity,
+                           average_price AS entry_price
+                    FROM trading.positions
+                    WHERE strategy_id = %s AND portfolio_id = %s AND updated_at >= %s
+                    ORDER BY updated_at ASC, symbol ASC
+                    """,
+                    (strategy_type, portfolio_id, incubation_start),
+                )
+                positions = cursor.fetchall()
+
+                cursor.execute(
+                    """
+                    SELECT timestamp AS date, equity
+                    FROM trading.equity_curve
+                    WHERE strategy_id = %s AND portfolio_id = %s AND timestamp >= %s
+                    ORDER BY timestamp ASC
+                    """,
+                    (strategy_type, portfolio_id, incubation_start),
+                )
+                equity_curve = cursor.fetchall()
+        finally:
+            conn.close()
+
+        return IncubationPerformanceRows(
+            positions=positions,
+            equity_curve=equity_curve,
+        )
+
+    def _fetch_lifecycle(self, cursor, strategy_id):
+        cursor.execute(
+            "SELECT lifecycle FROM trading.strategy_registry WHERE id = %s",
+            (strategy_id,),
+        )
+        return cursor.fetchone()
+
+    def _insert_lifecycle_audit(
+        self, cursor, strategy_id, before_state, after_state, reason, user_id
+    ):
+        cursor.execute(
+            """
+            INSERT INTO trading.strategy_lifecycle_log
+                (strategy_id, before_state, after_state, reason, user_id)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (strategy_id, before_state, after_state, reason, user_id),
+        )
+
+    def start_incubation(self, strategy_id, mock_capital, reason, user_id):
+        if mock_capital <= 0:
+            raise IncubationError("mock_capital must be positive")
+        if not reason or not reason.strip():
+            raise IncubationError("reason must be non-empty")
+
+        conn = self.connection_factory()
+        try:
+            with conn.cursor() as cursor:
+                row = self._fetch_lifecycle(cursor, strategy_id)
+                if row is None:
+                    raise IncubationError(f"Strategy {strategy_id} not found")
+
+                current_state = row["lifecycle"]
+                if current_state == "incubating":
+                    raise IncubationError(f"Strategy {strategy_id} is already incubating")
+
+                cursor.execute(
+                    """
+                    UPDATE trading.strategy_registry
+                    SET lifecycle = %s, mock_capital = %s,
+                        incubation_started_at = now(), updated_at = now()
+                    WHERE id = %s
+                    """,
+                    ("incubating", mock_capital, strategy_id),
+                )
+                self._insert_lifecycle_audit(
+                    cursor,
+                    strategy_id,
+                    current_state,
+                    "incubating",
+                    reason,
+                    user_id,
+                )
+            conn.commit()
+        except psycopg2.Error as exc:
+            conn.rollback()
+            raise IncubationError(f"Database error: {exc}") from exc
+        finally:
+            conn.close()
+
+    def promote_to_live(self, strategy_id, reason, user_id):
+        if not reason or not reason.strip():
+            raise IncubationError("reason must be non-empty")
+
+        conn = self.connection_factory()
+        try:
+            with conn.cursor() as cursor:
+                row = self._fetch_lifecycle(cursor, strategy_id)
+                if row is None:
+                    raise IncubationError(f"Strategy {strategy_id} not found")
+
+                current_state = row["lifecycle"]
+                if current_state != "incubating":
+                    raise IncubationError(
+                        f"Strategy {strategy_id} is not currently incubating"
+                    )
+
+                cursor.execute(
+                    """
+                    UPDATE trading.strategy_registry
+                    SET lifecycle = %s, mock_capital = NULL,
+                        incubation_started_at = NULL, updated_at = now()
+                    WHERE id = %s
+                    """,
+                    ("live", strategy_id),
+                )
+                self._insert_lifecycle_audit(
+                    cursor,
+                    strategy_id,
+                    "incubating",
+                    "live",
+                    reason,
+                    user_id,
+                )
+            conn.commit()
+        except psycopg2.Error as exc:
+            conn.rollback()
+            raise IncubationError(f"Database error: {exc}") from exc
+        finally:
+            conn.close()
+
+    def retire_strategy(self, strategy_id, reason, user_id):
+        if not reason or not reason.strip():
+            raise IncubationError("reason must be non-empty")
+
+        conn = self.connection_factory()
+        try:
+            with conn.cursor() as cursor:
+                row = self._fetch_lifecycle(cursor, strategy_id)
+                if row is None:
+                    raise IncubationError(f"Strategy {strategy_id} not found")
+
+                current_state = row["lifecycle"]
+                cursor.execute(
+                    """
+                    UPDATE trading.strategy_registry
+                    SET lifecycle = %s, mock_capital = NULL,
+                        incubation_started_at = NULL, updated_at = now()
+                    WHERE id = %s
+                    """,
+                    ("retired", strategy_id),
+                )
+                self._insert_lifecycle_audit(
+                    cursor,
+                    strategy_id,
+                    current_state,
+                    "retired",
+                    reason,
+                    user_id,
+                )
+            conn.commit()
+        except psycopg2.Error as exc:
+            conn.rollback()
+            raise IncubationError(f"Database error: {exc}") from exc
+        finally:
+            conn.close()

--- a/algolens-api/algolens/infrastructure/portfolio/strategy_registry.py
+++ b/algolens-api/algolens/infrastructure/portfolio/strategy_registry.py
@@ -18,6 +18,7 @@ DEFAULT_REGISTRY = [
         "initial_equity": 500000.0,
         "managers": ["AlgoLens System"],
         "is_active": True,
+        "lifecycle": "live",
         "sort_order": 0,
     }
 ]
@@ -36,8 +37,20 @@ def _normalize(row):
         else 500000.0,
         "managers": row.get("managers") or ["AlgoLens System"],
         "is_active": bool(row.get("is_active", True)),
+        "lifecycle": row.get("lifecycle") or "live",
         "sort_order": int(row.get("sort_order") or 0),
     }
+
+
+def _has_lifecycle_column(cursor):
+    cursor.execute(
+        """
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'trading' AND table_name = 'strategy_registry'
+          AND column_name = 'lifecycle'
+        """
+    )
+    return cursor.fetchone() is not None
 
 
 class PostgresStrategyRegistry:
@@ -49,14 +62,25 @@ class PostgresStrategyRegistry:
         try:
             conn = self.connection_factory()
             with conn.cursor() as cursor:
-                cursor.execute(
-                    """
-                    SELECT id, strategy_type, portfolio_id, name, description,
-                           initial_equity, managers, is_active, sort_order
-                    FROM trading.strategy_registry
-                    ORDER BY sort_order ASC, id ASC
-                    """
-                )
+                has_lifecycle = _has_lifecycle_column(cursor)
+                if has_lifecycle:
+                    cursor.execute(
+                        """
+                        SELECT id, strategy_type, portfolio_id, name, description,
+                               initial_equity, managers, is_active, lifecycle, sort_order
+                        FROM trading.strategy_registry
+                        ORDER BY sort_order ASC, id ASC
+                        """
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        SELECT id, strategy_type, portfolio_id, name, description,
+                               initial_equity, managers, is_active, sort_order
+                        FROM trading.strategy_registry
+                        ORDER BY sort_order ASC, id ASC
+                        """
+                    )
                 rows = cursor.fetchall()
 
             registry = [_normalize(row) for row in rows]
@@ -76,7 +100,11 @@ class PostgresStrategyRegistry:
                 conn.close()
 
         if active_only:
-            registry = [strategy for strategy in registry if strategy["is_active"]]
+            registry = [
+                strategy
+                for strategy in registry
+                if strategy["is_active"] and strategy.get("lifecycle", "live") == "live"
+            ]
         return registry
 
     def get(self, strategy_id):

--- a/algolens-api/migrations/002_strategy_lifecycle.sql
+++ b/algolens-api/migrations/002_strategy_lifecycle.sql
@@ -1,0 +1,50 @@
+-- Strategy lifecycle management: support incubation of strategies on mock capital.
+--
+-- Background: AlgoLens currently tracks only "live" strategies using real capital in
+-- the portfolio_id's trading tables (positions, equity_curve, live_results, executions).
+--
+-- This migration adds a "lifecycle" state machine to strategy_registry, allowing
+-- strategies to be moved into an "incubating" state where they run the same cron jobs
+-- (same backtests, same rebalance logic) against mock capital, walled off from the
+-- real portfolio. A strategy in incubation is completely invisible to the live
+-- portfolio dashboard and its metrics.
+--
+-- The default is 'live' deliberately: every pre-existing strategy_registry row (all
+-- of which run real capital) must retain its behavior and continue appearing in the
+-- real dashboard. Defaulting to 'incubating' would silently exclude them, breaking
+-- the entire live book on any deployment where this migration runs but the code to
+-- read the new column has not deployed yet.
+--
+-- The incubation window is 3-4 months: a strategy's mock performance is tracked from
+-- incubation_started_at onward, and mock_capital represents the notional equity the
+-- strategy trades against during incubation. Both are NULL for live strategies.
+--
+-- Safe to run more than once (ADD COLUMN IF NOT EXISTS, transactional).
+
+ALTER TABLE trading.strategy_registry
+    ADD COLUMN IF NOT EXISTS lifecycle TEXT NOT NULL DEFAULT 'live'
+        CHECK (lifecycle IN ('incubating', 'live', 'retired'));
+
+ALTER TABLE trading.strategy_registry
+    ADD COLUMN IF NOT EXISTS incubation_started_at TIMESTAMPTZ;
+
+ALTER TABLE trading.strategy_registry
+    ADD COLUMN IF NOT EXISTS mock_capital NUMERIC;
+
+-- Audit table: every lifecycle state transition is recorded with before/after state,
+-- reason, and user_id. This is as consequential as a position override and must be
+-- auditable.
+CREATE TABLE IF NOT EXISTS trading.strategy_lifecycle_log (
+    id                  SERIAL PRIMARY KEY,
+    strategy_id         TEXT NOT NULL REFERENCES trading.strategy_registry(id) ON DELETE CASCADE,
+    before_state        TEXT NOT NULL CHECK (before_state IN ('incubating', 'live', 'retired')),
+    after_state         TEXT NOT NULL CHECK (after_state IN ('incubating', 'live', 'retired')),
+    reason              TEXT NOT NULL,
+    user_id             TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for audit queries: look up transitions by strategy and date range
+CREATE INDEX IF NOT EXISTS idx_lifecycle_log_strategy_date
+    ON trading.strategy_lifecycle_log(strategy_id, created_at DESC);

--- a/algolens-api/tests/test_authorization.py
+++ b/algolens-api/tests/test_authorization.py
@@ -1,0 +1,52 @@
+"""Authorization tests for member-only incubation endpoints."""
+
+import pytest
+from flask_jwt_extended import create_access_token
+
+from app import app
+
+
+class EmptyIncubationReader:
+    def list_incubating_strategies(self):
+        return []
+
+
+def _set_jwt_cookie(client, role):
+    claims = {} if role is None else {"role": role}
+    with app.app_context():
+        token = create_access_token(identity="1", additional_claims=claims)
+    client.set_cookie("access_token_cookie", token)
+
+
+@pytest.fixture(autouse=True)
+def stub_portfolio_dependencies(monkeypatch):
+    import algolens.adapters.http.portfolio as portfolio_http
+
+    monkeypatch.setattr(
+        portfolio_http,
+        "create_portfolio_dependencies",
+        lambda: (object(), EmptyIncubationReader()),
+    )
+
+
+@pytest.mark.parametrize(
+    "role",
+    [None, "subscriber_individual", "subscriber_professional", "unknown"],
+)
+def test_non_internal_roles_are_refused_incubation_access(client, role):
+    _set_jwt_cookie(client, role)
+
+    response = client.get("/portfolio/incubation")
+
+    assert response.status_code == 403
+    assert response.get_json()["error"] == "Insufficient permissions"
+
+
+@pytest.mark.parametrize("role", ["admin", "general_member"])
+def test_internal_roles_can_access_incubation(client, role):
+    _set_jwt_cookie(client, role)
+
+    response = client.get("/portfolio/incubation")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"incubating_strategies": []}

--- a/algolens-api/tests/test_incubation.py
+++ b/algolens-api/tests/test_incubation.py
@@ -1,0 +1,161 @@
+"""Incubation application and repository tests.
+
+These are no-DB tests: use cases are exercised with small fakes, and the
+Postgres repository read path is driven by a fake cursor.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from algolens.application.portfolio.ports import IncubationError
+from algolens.application.portfolio.use_cases import (
+    GetIncubationPerformance,
+    PromoteToLive,
+    StartIncubation,
+)
+from algolens.domain.portfolio.incubation import compute_incubation_window
+from algolens.infrastructure.portfolio.repositories import PostgresPortfolioRepository
+
+
+def test_days_elapsed_is_never_negative_from_clock_skew():
+    started = datetime.now(timezone.utc)
+    host_now = started - timedelta(milliseconds=634)
+
+    raw = (host_now - started).days
+    assert raw == -1, "precondition: this is the floor() behavior being guarded"
+
+    window = compute_incubation_window(started, host_now)
+    assert window.days_elapsed == 0
+    assert window.window_days == 120
+    assert window.progress == 0
+
+
+class RecordingReader:
+    def __init__(self):
+        self.started = None
+        self.promoted = None
+
+    def start_incubation(self, **kwargs):
+        self.started = kwargs
+
+    def promote_to_live(self, **kwargs):
+        self.promoted = kwargs
+
+
+def test_start_incubation_requires_positive_mock_capital():
+    reader = RecordingReader()
+
+    with pytest.raises(IncubationError, match="mock_capital"):
+        StartIncubation(reader).execute(
+            strategy_id="trendfollowing",
+            mock_capital=0,
+            reason="Testing incubation",
+            user_id="1",
+        )
+
+    assert reader.started is None
+
+
+def test_promote_to_live_requires_non_empty_reason():
+    reader = RecordingReader()
+
+    with pytest.raises(IncubationError, match="reason"):
+        PromoteToLive(reader).execute(
+            strategy_id="trendfollowing",
+            reason="   ",
+            user_id="1",
+        )
+
+    assert reader.promoted is None
+
+
+class FakeCursor:
+    def __init__(self, incubation_start, positions, equity_curve):
+        self.incubation_start = incubation_start
+        self.positions = positions
+        self.equity_curve = equity_curve
+        self.calls = []
+        self.result = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+        if "FROM trading.strategy_registry" in sql:
+            self.result = {
+                "strategy_type": "LIVE_TREND_FOLLOWING",
+                "portfolio_id": "MOCK_PORTFOLIO",
+                "incubation_started_at": self.incubation_start,
+            }
+        elif "FROM trading.positions" in sql:
+            started_at = params[2]
+            self.result = [
+                row for row in self.positions if row["date"] >= started_at
+            ]
+        elif "FROM trading.equity_curve" in sql:
+            started_at = params[2]
+            self.result = [
+                row for row in self.equity_curve if row["date"] >= started_at
+            ]
+        else:
+            raise AssertionError(f"Unexpected SQL: {sql}")
+
+    def fetchone(self):
+        return self.result
+
+    def fetchall(self):
+        return self.result
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def close(self):
+        self.closed = True
+
+
+def test_incubation_performance_excludes_pre_incubation_history():
+    incubation_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    before = datetime(2026, 6, 30, tzinfo=timezone.utc)
+    after = datetime(2026, 7, 2, tzinfo=timezone.utc)
+    cursor = FakeCursor(
+        incubation_start=incubation_start,
+        positions=[
+            {"date": before, "symbol": "ES", "quantity": 1, "entry_price": 100},
+            {"date": after, "symbol": "NQ", "quantity": 2, "entry_price": 200},
+        ],
+        equity_curve=[
+            {"date": before, "equity": 249000},
+            {"date": after, "equity": 251000},
+        ],
+    )
+    repo = PostgresPortfolioRepository(
+        connection_factory=lambda: FakeConnection(cursor)
+    )
+
+    performance = GetIncubationPerformance(repo).execute("trendfollowing")
+
+    assert [position["date"] for position in performance["positions"]] == [after]
+    assert [point["date"] for point in performance["equity_curve"]] == [after]
+    position_call = next(call for call in cursor.calls if "trading.positions" in call[0])
+    equity_call = next(call for call in cursor.calls if "trading.equity_curve" in call[0])
+    assert position_call[1] == (
+        "LIVE_TREND_FOLLOWING",
+        "MOCK_PORTFOLIO",
+        incubation_start,
+    )
+    assert equity_call[1] == (
+        "LIVE_TREND_FOLLOWING",
+        "MOCK_PORTFOLIO",
+        incubation_start,
+    )

--- a/algolens-api/tests/test_incubation_routes.py
+++ b/algolens-api/tests/test_incubation_routes.py
@@ -1,0 +1,96 @@
+"""HTTP tests for incubation routes with repository dependencies stubbed."""
+
+from datetime import datetime, timezone
+
+from flask_jwt_extended import create_access_token
+
+from app import app
+
+
+def _set_jwt_cookie(client, role="admin"):
+    claims = {} if role is None else {"role": role}
+    with app.app_context():
+        token = create_access_token(identity="1", additional_claims=claims)
+    client.set_cookie("access_token_cookie", token)
+
+
+class FakeReader:
+    def list_incubating_strategies(self):
+        return [
+            {
+                "id": "trendfollowing",
+                "strategy_type": "LIVE_TREND_FOLLOWING",
+                "portfolio_id": "MOCK_PORTFOLIO",
+                "name": "Trend Following",
+                "description": "Mock-capital trial",
+                "mock_capital": 250000,
+                "incubation_started_at": datetime(2026, 7, 1, tzinfo=timezone.utc),
+            }
+        ]
+
+    def fetch_incubation_performance(self, strategy_id):
+        assert strategy_id == "trendfollowing"
+        from algolens.application.portfolio.ports import IncubationPerformanceRows
+
+        return IncubationPerformanceRows(
+            positions=[
+                {
+                    "date": datetime(2026, 7, 2, tzinfo=timezone.utc),
+                    "symbol": "ES",
+                    "quantity": 1,
+                    "entry_price": 100,
+                }
+            ],
+            equity_curve=[
+                {
+                    "date": datetime(2026, 7, 2, tzinfo=timezone.utc),
+                    "equity": 251000,
+                }
+            ],
+        )
+
+
+def test_get_incubation_strategies_returns_serialized_payload(client, monkeypatch):
+    import algolens.adapters.http.portfolio as portfolio_http
+
+    monkeypatch.setattr(
+        portfolio_http,
+        "create_portfolio_dependencies",
+        lambda: (object(), FakeReader()),
+    )
+    _set_jwt_cookie(client, role="admin")
+
+    response = client.get("/portfolio/incubation")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["incubating_strategies"][0]["id"] == "trendfollowing"
+    assert data["incubating_strategies"][0]["mock_capital"] == 250000.0
+    assert data["incubating_strategies"][0]["window_days"] == 120
+
+
+def test_get_incubation_performance_returns_serialized_payload(client, monkeypatch):
+    import algolens.adapters.http.portfolio as portfolio_http
+
+    monkeypatch.setattr(
+        portfolio_http,
+        "create_portfolio_dependencies",
+        lambda: (object(), FakeReader()),
+    )
+    _set_jwt_cookie(client, role="general_member")
+
+    response = client.get("/portfolio/incubation/trendfollowing/performance")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["positions"] == [
+        {
+            "date": "2026-07-02T00:00:00+00:00",
+            "symbol": "ES",
+            "quantity": 1.0,
+            "entry_price": 100.0,
+        }
+    ]
+    assert data["equity_curve"] == [
+        {"date": "2026-07-02T00:00:00+00:00", "equity": 251000.0}
+    ]

--- a/algolens-api/tests/test_strategy_registry.py
+++ b/algolens-api/tests/test_strategy_registry.py
@@ -1,0 +1,100 @@
+from algolens.infrastructure.portfolio.strategy_registry import PostgresStrategyRegistry
+
+
+class FakeCursor:
+    def __init__(self, *, has_lifecycle, rows):
+        self.has_lifecycle = has_lifecycle
+        self.rows = rows
+        self.calls = []
+        self.result = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+        if "information_schema.columns" in sql:
+            self.result = {"exists": 1} if self.has_lifecycle else None
+        elif "FROM trading.strategy_registry" in sql:
+            self.result = self.rows
+        else:
+            raise AssertionError(f"Unexpected SQL: {sql}")
+
+    def fetchone(self):
+        return self.result
+
+    def fetchall(self):
+        return self.result
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def close(self):
+        self.closed = True
+
+
+def make_row(strategy_id, *, lifecycle=None, is_active=True):
+    row = {
+        "id": strategy_id,
+        "strategy_type": f"{strategy_id.upper()}_TYPE",
+        "portfolio_id": f"{strategy_id.upper()}_PORTFOLIO",
+        "name": strategy_id.title(),
+        "description": "",
+        "initial_equity": 100000,
+        "managers": ["AlgoLens System"],
+        "is_active": is_active,
+        "sort_order": 0,
+    }
+    if lifecycle is not None:
+        row["lifecycle"] = lifecycle
+    return row
+
+
+def test_list_treats_missing_lifecycle_column_as_live():
+    cursor = FakeCursor(
+        has_lifecycle=False,
+        rows=[
+            make_row("alpha"),
+            make_row("beta"),
+            make_row("inactive", is_active=False),
+        ],
+    )
+    registry = PostgresStrategyRegistry(
+        connection_factory=lambda: FakeConnection(cursor)
+    )
+
+    strategies = registry.list(active_only=True)
+
+    assert [strategy["id"] for strategy in strategies] == ["alpha", "beta"]
+    assert all(strategy["lifecycle"] == "live" for strategy in strategies)
+    registry_select = cursor.calls[1][0]
+    assert "lifecycle" not in registry_select
+
+
+def test_list_filters_incubating_rows_when_lifecycle_column_exists():
+    cursor = FakeCursor(
+        has_lifecycle=True,
+        rows=[
+            make_row("live", lifecycle="live"),
+            make_row("incubating", lifecycle="incubating"),
+            make_row("inactive", lifecycle="live", is_active=False),
+        ],
+    )
+    registry = PostgresStrategyRegistry(
+        connection_factory=lambda: FakeConnection(cursor)
+    )
+
+    strategies = registry.list(active_only=True)
+
+    assert [strategy["id"] for strategy in strategies] == ["live"]
+    registry_select = cursor.calls[1][0]
+    assert "lifecycle" in registry_select

--- a/algolens-frontend/src/application/portfolio/portfolioService.ts
+++ b/algolens-frontend/src/application/portfolio/portfolioService.ts
@@ -1,4 +1,5 @@
 import type { PortfolioData, Strategy } from '../../domain/portfolio/portfolioData';
+import type { IncubatingStrategy, IncubationPerformance } from '../../domain/portfolio/incubationData';
 import { PortfolioApiService } from '../../infrastructure/api/portfolioApi';
 
 export class PortfolioApplicationService {
@@ -16,5 +17,13 @@ export class PortfolioApplicationService {
 
   static async getPortfolioData(): Promise<PortfolioData> {
     return PortfolioApiService.getPortfolioData();
+  }
+
+  static async getIncubationStrategies(): Promise<IncubatingStrategy[]> {
+    return PortfolioApiService.getIncubationStrategies();
+  }
+
+  static async getIncubationPerformance(strategyId: string): Promise<IncubationPerformance> {
+    return PortfolioApiService.getIncubationPerformance(strategyId);
   }
 }

--- a/algolens-frontend/src/components/BottomNav.tsx
+++ b/algolens-frontend/src/components/BottomNav.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Home, TrendingUp, FileText, User } from 'lucide-react';
+import { Home, TrendingUp, FileText, FlaskConical, User } from 'lucide-react';
+import { isInternalRole } from '../domain/identity/user';
+import { useAuth } from '../adapters/react/AuthContext';
 import { useTheme } from '../adapters/react/ThemeContext';
 
 interface BottomNavProps {
@@ -9,9 +11,14 @@ interface BottomNavProps {
 
 export function BottomNav({ activeTab = 'portfolio', onTabChange }: BottomNavProps) {
   const { theme } = useTheme();
+  const { user } = useAuth();
+  const isInternalMember = isInternalRole(user?.role);
   
   const tabs = [
     { id: 'portfolio', label: 'Portfolio', icon: Home },
+    ...(isInternalMember
+      ? [{ id: 'incubation', label: 'Incubation', icon: FlaskConical }]
+      : []),
     { id: 'builder', label: 'Builder', icon: TrendingUp },
     { id: 'news', label: 'News', icon: FileText },
     { id: 'profile', label: 'Profile', icon: User },
@@ -23,7 +30,9 @@ export function BottomNav({ activeTab = 'portfolio', onTabChange }: BottomNavPro
         ? 'bg-black border-gray-800' 
         : 'bg-white border-gray-200'
     }`}>
-      <div className="grid grid-cols-4">
+      <div
+        className={isInternalMember ? 'grid grid-cols-5' : 'grid grid-cols-4'}
+      >
         {tabs.map((tab) => {
           const Icon = tab.icon;
           const isActive = activeTab === tab.id;

--- a/algolens-frontend/src/components/Dashboard.tsx
+++ b/algolens-frontend/src/components/Dashboard.tsx
@@ -10,8 +10,11 @@ import { PrivacySettings } from './PrivacySettings';
 import { StrategyBuilder } from './StrategyBuilder';
 import { NewsView } from './NewsView';
 import { EmptyPortfolioScreen } from './EmptyPortfolioScreen';
+import { IncubationScreen } from './IncubationScreen';
 import type { PortfolioData } from '../domain/portfolio/portfolioData';
 import { PortfolioApplicationService } from '../application/portfolio/portfolioService';
+import { isInternalRole } from '../domain/identity/user';
+import { useAuth } from '../adapters/react/AuthContext';
 import { useTheme } from '../adapters/react/ThemeContext';
 
 interface DashboardProps {
@@ -19,7 +22,7 @@ interface DashboardProps {
 }
 
 type SettingsScreen = 'profile' | 'account' | 'privacy' | null;
-type ActiveTab = 'portfolio' | 'builder' | 'news' | 'profile';
+type ActiveTab = 'portfolio' | 'incubation' | 'builder' | 'news' | 'profile';
 
 export function Dashboard({ onLogout }: DashboardProps) {
   const [selectedStrategy, setSelectedStrategy] = useState<string | null>(null);
@@ -30,6 +33,8 @@ export function Dashboard({ onLogout }: DashboardProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { theme } = useTheme();
+  const { user } = useAuth();
+  const isInternalMember = isInternalRole(user?.role);
 
   // Fetch portfolio data on mount
   useEffect(() => {
@@ -70,11 +75,22 @@ export function Dashboard({ onLogout }: DashboardProps) {
     fetchPortfolioData();
   }, []);
 
+  useEffect(() => {
+    if (activeTab === 'incubation' && !isInternalMember) {
+      setActiveTab('portfolio');
+      setSelectedStrategy(null);
+    }
+  }, [activeTab, isInternalMember]);
+
   // Check if portfolio has any positions
   const hasPositions = portfolioData?.strategies && portfolioData.strategies.length > 0 &&
     portfolioData.strategies.some(s => s.positions.length > 0);
 
   const handleTabChange = (tab: string) => {
+    if (tab === 'incubation' && !isInternalMember) {
+      return;
+    }
+
     setActiveTab(tab as ActiveTab);
     setSelectedStrategy(null);
 
@@ -114,6 +130,13 @@ export function Dashboard({ onLogout }: DashboardProps) {
           onHomeClick={() => {
             setShowBuilder(false);
             setActiveTab('portfolio');
+            setSelectedStrategy(null);
+          }}
+          onIncubationClick={() => {
+            if (!isInternalMember) return;
+            setShowBuilder(false);
+            setSettingsScreen(null);
+            setActiveTab('incubation');
             setSelectedStrategy(null);
           }}
         />
@@ -185,6 +208,12 @@ export function Dashboard({ onLogout }: DashboardProps) {
               onBack={() => setSelectedStrategy(null)}
             />
           )}
+        </div>
+      )}
+
+      {activeTab === 'incubation' && isInternalMember && (
+        <div className="max-w-5xl mx-auto px-4 md:px-6 py-6 md:py-8">
+          <IncubationScreen />
         </div>
       )}
 

--- a/algolens-frontend/src/components/Header.tsx
+++ b/algolens-frontend/src/components/Header.tsx
@@ -1,19 +1,30 @@
 import React, { useState, useEffect } from 'react';
-import { Bell, User, X } from 'lucide-react';
+import { Bell, FlaskConical, User, X } from 'lucide-react';
 import logo from '../assets/logo.png';
+import { isInternalRole } from '../domain/identity/user';
+import { useAuth } from '../adapters/react/AuthContext';
 import { useTheme } from '../adapters/react/ThemeContext';
 
 interface HeaderProps {
   onProfileClick: () => void;
   onBuilderClick?: () => void;
   onHomeClick?: () => void;
-  activeTab?: 'portfolio' | 'builder' | 'news' | 'profile';
+  onIncubationClick?: () => void;
+  activeTab?: 'portfolio' | 'incubation' | 'builder' | 'news' | 'profile';
 }
 
-export function Header({ onProfileClick, onBuilderClick, onHomeClick, activeTab = 'portfolio' }: HeaderProps) {
+export function Header({
+  onProfileClick,
+  onBuilderClick,
+  onHomeClick,
+  onIncubationClick,
+  activeTab = 'portfolio',
+}: HeaderProps) {
   const { theme } = useTheme();
+  const { user } = useAuth();
   const [showNotification, setShowNotification] = useState(false);
   const [hasNewNotification, setHasNewNotification] = useState(false);
+  const isInternalMember = isInternalRole(user?.role);
 
   const OUTLOOK_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=9199bf20-a13f-4107-85dc-02114787ef48&scope=https%3A%2F%2Foutlook.office.com%2F.default%20openid%20profile%20offline_access&redirect_uri=https%3A%2F%2Foutlook.live.com%2Fmail%2F&client-request-id=db1c7baa-e08c-3071-7a19-53c59751400e&response_mode=fragment&client_info=1&prompt=select_account&nonce=019b9607-602c-78ec-971e-ab36297d8aed&state=eyJpZCI6IjAxOWI5NjA3LTYwMmMtNzY4MS05NGI3LTkzZDZlZDI4ZjdiZiIsIm1ldGEiOnsiaW50ZXJhY3Rpb25UeXBlIjoicmVkaXJlY3QifX0%3D%7CaHR0cHM6Ly9vdXRsb29rLmxpdmUuY29tL21haWwvMC8_ZGVlcGxpbms9bWFpbCUyRjAlMkY&claims=%7B%22access_token%22%3A%7B%22xms_cc%22%3A%7B%22values%22%3A%5B%22CP1%22%5D%7D%7D%7D&x-client-SKU=msal.js.browser&x-client-VER=4.26.0&response_type=code&code_challenge=edvy3GffheuAG3xMagQGunjdE7B2ST-J3LKoL2izw9Q&code_challenge_method=S256&cobrandid=ab0455a0-8d03-46b9-b18b-df2f57b9e44c&fl=dob,flname,wld';
 
@@ -105,6 +116,22 @@ export function Header({ onProfileClick, onBuilderClick, onHomeClick, activeTab 
               >
                 Strategy Builder
               </button>
+              {isInternalMember && (
+                <button
+                  onClick={onIncubationClick}
+                  className={`transition-colors flex items-center gap-2 ${activeTab === 'incubation'
+                    ? theme === 'dark'
+                      ? 'text-white font-semibold'
+                      : 'text-black font-semibold'
+                    : theme === 'dark'
+                      ? 'text-gray-400 hover:text-orange-500'
+                      : 'text-gray-500 hover:text-orange-500'
+                    }`}
+                >
+                  <FlaskConical className="w-4 h-4" />
+                  Incubation
+                </button>
+              )}
             </nav>
           </div>
 

--- a/algolens-frontend/src/components/IncubationDetail.tsx
+++ b/algolens-frontend/src/components/IncubationDetail.tsx
@@ -1,0 +1,326 @@
+import React, { useMemo, useState } from 'react';
+import { ArrowLeft, Clock, TrendingDown, TrendingUp } from 'lucide-react';
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type {
+  IncubatingStrategy,
+  IncubationPerformance,
+} from '../domain/portfolio/incubationData';
+import {
+  calculateDaysRemaining,
+  calculateIncubationProgress,
+  formatEquity,
+  formatIncubationDate,
+  formatMockCapital,
+} from '../domain/portfolio/incubationUtils';
+import { useTheme } from '../adapters/react/ThemeContext';
+
+interface IncubationDetailProps {
+  strategy: IncubatingStrategy;
+  performance: IncubationPerformance | null;
+  isLoading: boolean;
+  error: string | null;
+  onBack: () => void;
+}
+
+export function IncubationDetail({
+  strategy,
+  performance,
+  isLoading,
+  error,
+  onBack,
+}: IncubationDetailProps) {
+  const [selectedPeriod, setSelectedPeriod] = useState('1M');
+  const { theme } = useTheme();
+  const periods = ['1W', '1M', '3M', 'ALL'];
+
+  const historicalData = useMemo(
+    () =>
+      (performance?.equity_curve || [])
+        .filter(point => point.equity !== null)
+        .map(point => ({ date: point.date, value: point.equity || 0 })),
+    [performance]
+  );
+
+  const filteredData = useMemo(() => {
+    if (selectedPeriod === 'ALL') return historicalData;
+
+    const daysToShow =
+      selectedPeriod === '1W' ? 7 : selectedPeriod === '1M' ? 30 : 90;
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - daysToShow);
+
+    return historicalData.filter(point => new Date(point.date) >= cutoffDate);
+  }, [historicalData, selectedPeriod]);
+
+  const periodReturn = useMemo(() => {
+    if (filteredData.length < 2) return { value: 0, percent: 0 };
+    const startValue = filteredData[0].value;
+    const endValue = filteredData[filteredData.length - 1].value;
+    const returnValue = endValue - startValue;
+    const returnPercent = startValue > 0 ? (returnValue / startValue) * 100 : 0;
+    return { value: returnValue, percent: returnPercent };
+  }, [filteredData]);
+
+  const currentEquity =
+    historicalData.length > 0
+      ? historicalData[historicalData.length - 1].value
+      : strategy.mock_capital || 0;
+  const progress = calculateIncubationProgress(
+    strategy.days_elapsed,
+    strategy.window_days
+  );
+  const daysRemaining = calculateDaysRemaining(
+    strategy.days_elapsed,
+    strategy.window_days
+  );
+  const periodLabel = selectedPeriod === 'ALL' ? 'All Time' : selectedPeriod;
+
+  return (
+    <div>
+      <button
+        onClick={onBack}
+        className={`flex items-center gap-2 mb-6 px-4 py-2 rounded-lg transition-colors ${
+          theme === 'dark'
+            ? 'text-gray-300 hover:text-white hover:bg-gray-900'
+            : 'text-gray-700 hover:text-black hover:bg-gray-100'
+        }`}
+      >
+        <ArrowLeft className="w-5 h-5" />
+        <span>Back to Incubation</span>
+      </button>
+
+      <div className="mb-6">
+        <h1 className="text-2xl md:text-3xl mb-1">{strategy.name}</h1>
+        <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}>
+          {strategy.description || strategy.id}
+        </p>
+        <div
+          className={`text-sm mt-2 flex flex-wrap items-center gap-3 ${
+            theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+          }`}
+        >
+          <span>{formatMockCapital(strategy.mock_capital)} mock capital</span>
+          <span>•</span>
+          <span>Started {formatIncubationDate(strategy.incubation_started_at)}</span>
+          <span>•</span>
+          <span className="flex items-center gap-1">
+            <Clock className="w-4 h-4" />
+            {strategy.days_elapsed}d / {strategy.window_days}d
+          </span>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center min-h-[320px]">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-500 mx-auto mb-4"></div>
+            <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
+              Loading incubation performance...
+            </p>
+          </div>
+        </div>
+      ) : error ? (
+        <div className="flex items-center justify-center min-h-[320px]">
+          <div className="text-center max-w-lg">
+            <div className="mb-4 p-4 bg-red-100 dark:bg-red-900/30 rounded-lg">
+              <p className="text-red-600 dark:text-red-400 text-sm font-mono break-words text-left">
+                {error}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="mb-6">
+            <div className="text-3xl md:text-4xl mb-2">
+              {formatEquity(currentEquity)}
+            </div>
+            <div
+              className={`flex items-center gap-2 text-lg ${
+                periodReturn.value >= 0 ? 'text-orange-500' : 'text-red-500'
+              }`}
+            >
+              {periodReturn.value >= 0 ? (
+                <TrendingUp className="w-5 h-5" />
+              ) : (
+                <TrendingDown className="w-5 h-5" />
+              )}
+              <span>
+                ${Math.abs(periodReturn.value).toLocaleString('en-US', {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}{' '}
+                ({periodReturn.percent >= 0 ? '+' : ''}
+                {periodReturn.percent.toFixed(2)}%) {periodLabel}
+              </span>
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={filteredData}>
+                <XAxis dataKey="date" hide />
+                <YAxis hide domain={['dataMin - 500', 'dataMax + 500']} />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: theme === 'dark' ? '#1f2937' : '#fff',
+                    border:
+                      theme === 'dark'
+                        ? '1px solid #374151'
+                        : '1px solid #e5e7eb',
+                    borderRadius: '8px',
+                    boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+                    color: theme === 'dark' ? '#fff' : '#000',
+                  }}
+                  formatter={(value: number) => [
+                    `$${value.toLocaleString('en-US', {
+                      minimumFractionDigits: 2,
+                    })}`,
+                    'Mock Equity',
+                  ]}
+                  labelFormatter={label =>
+                    new Date(label).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })
+                  }
+                />
+                <Line
+                  type="linear"
+                  dataKey="value"
+                  stroke={periodReturn.value >= 0 ? '#f97316' : '#ef4444'}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div
+            className={`flex items-center justify-between mb-8 border-b ${
+              theme === 'dark' ? 'border-gray-800' : 'border-gray-200'
+            }`}
+          >
+            {periods.map(period => (
+              <button
+                key={period}
+                onClick={() => setSelectedPeriod(period)}
+                className={`px-3 py-3 text-sm transition-colors relative ${
+                  selectedPeriod === period
+                    ? 'text-orange-500'
+                    : theme === 'dark'
+                      ? 'text-gray-400 hover:text-white'
+                      : 'text-gray-500 hover:text-gray-900'
+                }`}
+              >
+                {period}
+                {selectedPeriod === period && (
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
+                )}
+              </button>
+            ))}
+          </div>
+
+          <div
+            className={`grid grid-cols-1 md:grid-cols-3 gap-4 mb-8 border-y py-4 ${
+              theme === 'dark' ? 'border-gray-800' : 'border-gray-200'
+            }`}
+          >
+            <div>
+              <div
+                className={`text-xs mb-1 uppercase tracking-wider ${
+                  theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                }`}
+              >
+                Progress
+              </div>
+              <div className="text-2xl">{Math.round(progress)}%</div>
+            </div>
+            <div>
+              <div
+                className={`text-xs mb-1 uppercase tracking-wider ${
+                  theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                }`}
+              >
+                Remaining
+              </div>
+              <div className="text-2xl">{daysRemaining}d</div>
+            </div>
+            <div>
+              <div
+                className={`text-xs mb-1 uppercase tracking-wider ${
+                  theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                }`}
+              >
+                Positions
+              </div>
+              <div className="text-2xl">{performance?.positions.length || 0}</div>
+            </div>
+          </div>
+
+          <div>
+            <h3
+              className={`text-sm uppercase tracking-wider mb-4 ${
+                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+              }`}
+            >
+              Incubation Positions
+            </h3>
+            <div
+              className={`border rounded-lg overflow-x-auto ${
+                theme === 'dark' ? 'border-gray-800' : 'border-gray-200'
+              }`}
+            >
+              <div
+                className={`grid grid-cols-4 gap-4 p-4 text-sm min-w-[640px] border-b ${
+                  theme === 'dark'
+                    ? 'bg-gray-900 border-gray-800 text-gray-400'
+                    : 'bg-gray-50 border-gray-200 text-gray-500'
+                }`}
+              >
+                <div>Date</div>
+                <div>Symbol</div>
+                <div className="text-right">Quantity</div>
+                <div className="text-right">Entry Price</div>
+              </div>
+              {(performance?.positions || []).map((position, index) => (
+                <div
+                  key={`${position.date}-${position.symbol}-${index}`}
+                  className={`grid grid-cols-4 gap-4 p-4 min-w-[640px] ${
+                    theme === 'dark' ? 'hover:bg-gray-900' : 'hover:bg-gray-50'
+                  } ${
+                    index !== (performance?.positions.length || 0) - 1
+                      ? theme === 'dark'
+                        ? 'border-b border-gray-800'
+                        : 'border-b border-gray-200'
+                      : ''
+                  }`}
+                >
+                  <div>{formatIncubationDate(position.date)}</div>
+                  <div>{position.symbol}</div>
+                  <div className="text-right">{position.quantity ?? 0}</div>
+                  <div className="text-right">
+                    {position.entry_price === null
+                      ? 'N/A'
+                      : `$${position.entry_price.toLocaleString('en-US', {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}`}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/algolens-frontend/src/components/IncubationList.tsx
+++ b/algolens-frontend/src/components/IncubationList.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import {
+  ChevronRight,
+  Clock,
+  DollarSign,
+  FlaskConical,
+  Sprout,
+} from 'lucide-react';
+import type { IncubatingStrategy } from '../domain/portfolio/incubationData';
+import {
+  calculateDaysRemaining,
+  calculateIncubationProgress,
+  formatIncubationDate,
+  formatMockCapital,
+  isNearEndOfWindow,
+  isWindowComplete,
+} from '../domain/portfolio/incubationUtils';
+import { useTheme } from '../adapters/react/ThemeContext';
+
+interface IncubationListProps {
+  strategies: IncubatingStrategy[];
+  onSelectStrategy: (id: string) => void;
+}
+
+export function IncubationList({
+  strategies,
+  onSelectStrategy,
+}: IncubationListProps) {
+  const { theme } = useTheme();
+
+  if (strategies.length === 0) {
+    return (
+      <div className="text-center py-12 px-6">
+        <FlaskConical
+          className={`w-12 h-12 mx-auto mb-4 ${
+            theme === 'dark' ? 'text-gray-600' : 'text-gray-300'
+          }`}
+        />
+        <h3
+          className={`text-lg mb-2 ${
+            theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+          }`}
+        >
+          No Incubating Strategies
+        </h3>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-1 gap-4">
+      {strategies.map(strategy => {
+        const progress = calculateIncubationProgress(
+          strategy.days_elapsed,
+          strategy.window_days
+        );
+        const daysRemaining = calculateDaysRemaining(
+          strategy.days_elapsed,
+          strategy.window_days
+        );
+        const isComplete = isWindowComplete(
+          strategy.days_elapsed,
+          strategy.window_days
+        );
+        const isNearEnd =
+          isNearEndOfWindow(strategy.days_elapsed, strategy.window_days) &&
+          !isComplete;
+
+        return (
+          <button
+            key={strategy.id}
+            onClick={() => onSelectStrategy(strategy.id)}
+            className={`p-5 md:p-6 rounded-xl border transition-all text-left group ${
+              theme === 'dark'
+                ? 'bg-gray-900 border-gray-800 hover:border-orange-500 hover:bg-gray-800'
+                : 'bg-gray-50 border-gray-200 hover:border-orange-500 hover:bg-white hover:shadow-lg'
+            }`}
+          >
+            <div className="flex items-start justify-between mb-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-2">
+                  <div
+                    className={`p-2 rounded-lg ${
+                      theme === 'dark' ? 'bg-gray-800' : 'bg-white'
+                    }`}
+                  >
+                    <Sprout className="w-5 h-5 text-orange-500" />
+                  </div>
+                  <h3 className="text-lg">{strategy.name}</h3>
+                </div>
+                <p
+                  className={`text-sm mb-2 ${
+                    theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                  }`}
+                >
+                  {strategy.description || strategy.id}
+                </p>
+                <div
+                  className={`text-sm flex flex-wrap items-center gap-3 ${
+                    theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                  }`}
+                >
+                  <span>Started {formatIncubationDate(strategy.incubation_started_at)}</span>
+                  <span>•</span>
+                  <span>{strategy.portfolio_id}</span>
+                </div>
+              </div>
+
+              <ChevronRight
+                className={`w-5 h-5 flex-shrink-0 ml-3 transition-transform group-hover:translate-x-1 ${
+                  theme === 'dark' ? 'text-gray-600' : 'text-gray-400'
+                }`}
+              />
+            </div>
+
+            <div
+              className={`pt-4 border-t ${
+                theme === 'dark' ? 'border-gray-800' : 'border-gray-200'
+              }`}
+            >
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div>
+                  <div
+                    className={`text-xs mb-1 uppercase tracking-wider ${
+                      theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                    }`}
+                  >
+                    Mock Capital
+                  </div>
+                  <div className="text-lg flex items-center gap-1">
+                    <DollarSign className="w-4 h-4 text-orange-500" />
+                    {formatMockCapital(strategy.mock_capital).replace('$', '')}
+                  </div>
+                </div>
+
+                <div>
+                  <div
+                    className={`text-xs mb-1 uppercase tracking-wider ${
+                      theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                    }`}
+                  >
+                    Elapsed
+                  </div>
+                  <div className="text-lg flex items-center gap-1">
+                    <Clock className="w-4 h-4 text-orange-500" />
+                    {strategy.days_elapsed}d
+                  </div>
+                </div>
+
+                <div>
+                  <div
+                    className={`text-xs mb-1 uppercase tracking-wider ${
+                      theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                    }`}
+                  >
+                    Remaining
+                  </div>
+                  <div className="text-lg">{daysRemaining}d</div>
+                </div>
+
+                <div>
+                  <div
+                    className={`text-xs mb-1 uppercase tracking-wider ${
+                      theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                    }`}
+                  >
+                    Status
+                  </div>
+                  <div
+                    className={`text-lg ${
+                      isComplete
+                        ? 'text-emerald-500'
+                        : isNearEnd
+                          ? 'text-amber-500'
+                          : 'text-orange-500'
+                    }`}
+                  >
+                    {isComplete
+                      ? 'Complete'
+                      : isNearEnd
+                        ? 'Ending Soon'
+                        : `${Math.round(progress)}%`}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <div
+                  className={`h-2 rounded-full overflow-hidden ${
+                    theme === 'dark' ? 'bg-gray-800' : 'bg-gray-200'
+                  }`}
+                >
+                  <div
+                    className={`h-full transition-all ${
+                      isComplete
+                        ? 'bg-emerald-500'
+                        : isNearEnd
+                          ? 'bg-amber-500'
+                          : 'bg-orange-500'
+                    }`}
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/algolens-frontend/src/components/IncubationOverview.tsx
+++ b/algolens-frontend/src/components/IncubationOverview.tsx
@@ -1,0 +1,170 @@
+import React, { useMemo } from 'react';
+import { Clock, FlaskConical, TrendingUp } from 'lucide-react';
+import type { IncubatingStrategy } from '../domain/portfolio/incubationData';
+import {
+  calculateIncubationProgress,
+  calculateDaysRemaining,
+  formatMockCapital,
+  isNearEndOfWindow,
+  isWindowComplete,
+} from '../domain/portfolio/incubationUtils';
+import { useTheme } from '../adapters/react/ThemeContext';
+
+interface IncubationOverviewProps {
+  strategies: IncubatingStrategy[];
+}
+
+export function IncubationOverview({ strategies }: IncubationOverviewProps) {
+  const { theme } = useTheme();
+
+  const summary = useMemo(() => {
+    const totalMockCapital = strategies.reduce(
+      (sum, strategy) => sum + (strategy.mock_capital || 0),
+      0
+    );
+    const averageProgress =
+      strategies.length > 0
+        ? strategies.reduce(
+            (sum, strategy) =>
+              sum +
+              calculateIncubationProgress(
+                strategy.days_elapsed,
+                strategy.window_days
+              ),
+            0
+          ) / strategies.length
+        : 0;
+    const completed = strategies.filter(strategy =>
+      isWindowComplete(strategy.days_elapsed, strategy.window_days)
+    ).length;
+    const nearEnd = strategies.filter(
+      strategy =>
+        isNearEndOfWindow(strategy.days_elapsed, strategy.window_days) &&
+        !isWindowComplete(strategy.days_elapsed, strategy.window_days)
+    ).length;
+
+    return { totalMockCapital, averageProgress, completed, nearEnd };
+  }, [strategies]);
+
+  return (
+    <div className="mb-8">
+      <div className="mb-4">
+        <h2
+          className={`text-sm uppercase tracking-wider mb-2 ${
+            theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+          }`}
+        >
+          Mock Capital Incubation
+        </h2>
+      </div>
+
+      <div className="mb-6">
+        <div className="flex items-center gap-3 mb-2">
+          <FlaskConical className="w-8 h-8 text-orange-500" />
+          <div className="text-4xl md:text-5xl">
+            {formatMockCapital(summary.totalMockCapital)}
+          </div>
+        </div>
+        <div
+          className={`flex flex-wrap items-center gap-x-4 gap-y-2 text-lg ${
+            theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+          }`}
+        >
+          <span>{strategies.length} incubating strategies</span>
+          <span className="hidden sm:inline">•</span>
+          <span className="flex items-center gap-2 text-orange-500">
+            <TrendingUp className="w-5 h-5" />
+            {Math.round(summary.averageProgress)}% average progress
+          </span>
+        </div>
+      </div>
+
+      <div
+        className={`grid grid-cols-1 md:grid-cols-3 gap-4 mb-8 border-y py-4 ${
+          theme === 'dark' ? 'border-gray-800' : 'border-gray-200'
+        }`}
+      >
+        <div>
+          <div
+            className={`text-xs mb-1 uppercase tracking-wider ${
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+            }`}
+          >
+            Window Complete
+          </div>
+          <div className="text-2xl">{summary.completed}</div>
+        </div>
+        <div>
+          <div
+            className={`text-xs mb-1 uppercase tracking-wider ${
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+            }`}
+          >
+            Ending Soon
+          </div>
+          <div className="text-2xl">{summary.nearEnd}</div>
+        </div>
+        <div>
+          <div
+            className={`text-xs mb-1 uppercase tracking-wider ${
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+            }`}
+          >
+            Observation Window
+          </div>
+          <div className="text-2xl">120 days</div>
+        </div>
+      </div>
+
+      {strategies.length > 0 && (
+        <div className="space-y-3 mb-8">
+          {strategies.map(strategy => {
+            const progress = calculateIncubationProgress(
+              strategy.days_elapsed,
+              strategy.window_days
+            );
+            const daysRemaining = calculateDaysRemaining(
+              strategy.days_elapsed,
+              strategy.window_days
+            );
+
+            return (
+              <div key={strategy.id}>
+                <div className="flex items-center justify-between gap-3 mb-2">
+                  <div className="min-w-0">
+                    <div className="truncate">{strategy.name}</div>
+                    <div
+                      className={`text-sm flex items-center gap-1 ${
+                        theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                      }`}
+                    >
+                      <Clock className="w-4 h-4" />
+                      {strategy.days_elapsed}d elapsed, {daysRemaining}d remaining
+                    </div>
+                  </div>
+                  <div className="text-sm text-orange-500">
+                    {Math.round(progress)}%
+                  </div>
+                </div>
+                <div
+                  className={`h-2 rounded-full overflow-hidden ${
+                    theme === 'dark' ? 'bg-gray-800' : 'bg-gray-200'
+                  }`}
+                >
+                  <div
+                    className="h-full bg-orange-500 transition-all"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl">Incubating Strategies</h2>
+      </div>
+    </div>
+  );
+}

--- a/algolens-frontend/src/components/IncubationScreen.tsx
+++ b/algolens-frontend/src/components/IncubationScreen.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from 'react';
+import type {
+  IncubatingStrategy,
+  IncubationPerformance,
+} from '../domain/portfolio/incubationData';
+import { PortfolioApplicationService } from '../application/portfolio/portfolioService';
+import { useTheme } from '../adapters/react/ThemeContext';
+import { IncubationDetail } from './IncubationDetail';
+import { IncubationList } from './IncubationList';
+import { IncubationOverview } from './IncubationOverview';
+
+export function IncubationScreen() {
+  const { theme } = useTheme();
+  const [strategies, setStrategies] = useState<IncubatingStrategy[]>([]);
+  const [selectedStrategyId, setSelectedStrategyId] = useState<string | null>(null);
+  const [performance, setPerformance] = useState<IncubationPerformance | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStrategies = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const data = await PortfolioApplicationService.getIncubationStrategies();
+        setStrategies(data);
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        setError(`Failed to load incubation data: ${errorMessage}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStrategies();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedStrategyId) {
+      setPerformance(null);
+      setDetailError(null);
+      return;
+    }
+
+    const fetchPerformance = async () => {
+      try {
+        setIsDetailLoading(true);
+        setDetailError(null);
+        const data =
+          await PortfolioApplicationService.getIncubationPerformance(
+            selectedStrategyId
+          );
+        setPerformance(data);
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        setDetailError(`Failed to load incubation performance: ${errorMessage}`);
+      } finally {
+        setIsDetailLoading(false);
+      }
+    };
+
+    fetchPerformance();
+  }, [selectedStrategyId]);
+
+  const selectedStrategy = strategies.find(
+    strategy => strategy.id === selectedStrategyId
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-500 mx-auto mb-4"></div>
+          <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
+            Loading incubation data...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center max-w-lg">
+          <div className="mb-4 p-4 bg-red-100 dark:bg-red-900/30 rounded-lg">
+            <p className="text-red-600 dark:text-red-400 text-sm font-mono break-words text-left max-h-40 overflow-auto">
+              {error}
+            </p>
+          </div>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (selectedStrategy) {
+    return (
+      <IncubationDetail
+        strategy={selectedStrategy}
+        performance={performance}
+        isLoading={isDetailLoading}
+        error={detailError}
+        onBack={() => setSelectedStrategyId(null)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <IncubationOverview strategies={strategies} />
+      <IncubationList
+        strategies={strategies}
+        onSelectStrategy={setSelectedStrategyId}
+      />
+    </>
+  );
+}

--- a/algolens-frontend/src/domain/identity/user.ts
+++ b/algolens-frontend/src/domain/identity/user.ts
@@ -9,3 +9,9 @@ export interface User {
 export interface AuthResponse {
   user: User;
 }
+
+const INTERNAL_ROLES = new Set(['admin', 'general_member']);
+
+export function isInternalRole(role?: string | null): boolean {
+  return role ? INTERNAL_ROLES.has(role) : false;
+}

--- a/algolens-frontend/src/domain/portfolio/incubationData.ts
+++ b/algolens-frontend/src/domain/portfolio/incubationData.ts
@@ -1,0 +1,29 @@
+export interface IncubatingStrategy {
+  id: string;
+  name: string;
+  description?: string;
+  strategy_type: string;
+  portfolio_id: string;
+  mock_capital: number | null;
+  incubation_started_at: string | null;
+  days_elapsed: number;
+  window_days: number;
+  progress?: number;
+}
+
+export interface IncubationPosition {
+  date: string;
+  symbol: string;
+  quantity: number | null;
+  entry_price: number | null;
+}
+
+export interface IncubationEquityPoint {
+  date: string;
+  equity: number | null;
+}
+
+export interface IncubationPerformance {
+  positions: IncubationPosition[];
+  equity_curve: IncubationEquityPoint[];
+}

--- a/algolens-frontend/src/domain/portfolio/incubationUtils.test.ts
+++ b/algolens-frontend/src/domain/portfolio/incubationUtils.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateDaysRemaining,
+  calculateIncubationProgress,
+  formatEquity,
+  formatIncubationDate,
+  formatMockCapital,
+  INCUBATION_WINDOW_DAYS,
+  isNearEndOfWindow,
+  isWindowComplete,
+  validateMockCapital,
+  validateReason,
+} from './incubationUtils';
+
+describe('incubationUtils', () => {
+  describe('calculateIncubationProgress', () => {
+    it('returns 0 at day 0', () => {
+      expect(calculateIncubationProgress(0)).toBe(0);
+    });
+
+    it('returns 50 at day 60', () => {
+      expect(calculateIncubationProgress(60)).toBe(50);
+    });
+
+    it('returns 100 at day 120', () => {
+      expect(calculateIncubationProgress(120)).toBe(100);
+    });
+
+    it('caps progress at 100 if past window', () => {
+      expect(calculateIncubationProgress(150)).toBe(100);
+    });
+
+    it('clamps negative elapsed days at 0', () => {
+      expect(calculateIncubationProgress(-1)).toBe(0);
+    });
+
+    it('handles zero window gracefully', () => {
+      expect(calculateIncubationProgress(10, 0)).toBe(0);
+    });
+  });
+
+  describe('calculateDaysRemaining', () => {
+    it('uses the default incubation window', () => {
+      expect(calculateDaysRemaining(20)).toBe(INCUBATION_WINDOW_DAYS - 20);
+    });
+
+    it('does not return negative days', () => {
+      expect(calculateDaysRemaining(150)).toBe(0);
+    });
+  });
+
+  describe('formatIncubationDate', () => {
+    it('formats ISO date string', () => {
+      expect(formatIncubationDate('2026-07-26T12:00:00Z')).toMatch(
+        /Jul 26, 2026/
+      );
+    });
+
+    it('returns N/A for null', () => {
+      expect(formatIncubationDate(null)).toBe('N/A');
+    });
+
+    it('returns Invalid for malformed date', () => {
+      expect(formatIncubationDate('not a date')).toBe('Invalid');
+    });
+  });
+
+  describe('formatMockCapital', () => {
+    it('formats whole-dollar mock capital', () => {
+      expect(formatMockCapital(250000)).toBe('$250,000');
+    });
+
+    it('returns $0 for nullish input', () => {
+      expect(formatMockCapital(null)).toBe('$0');
+      expect(formatMockCapital(undefined)).toBe('$0');
+    });
+  });
+
+  describe('validateMockCapital', () => {
+    it('accepts valid numeric string', () => {
+      expect(validateMockCapital('250000')).toEqual([true, '']);
+    });
+
+    it('rejects non-positive capital', () => {
+      const [valid, message] = validateMockCapital(0);
+      expect(valid).toBe(false);
+      expect(message).toContain('greater than zero');
+    });
+
+    it('rejects too-small capital', () => {
+      const [valid, message] = validateMockCapital(50000);
+      expect(valid).toBe(false);
+      expect(message).toContain('at least $100,000');
+    });
+  });
+
+  describe('validateReason', () => {
+    it('accepts valid reason', () => {
+      expect(validateReason('Testing new momentum strategy')).toEqual([true, '']);
+    });
+
+    it('rejects whitespace-only reason', () => {
+      const [valid, message] = validateReason('   ');
+      expect(valid).toBe(false);
+      expect(message).toContain('cannot be empty');
+    });
+  });
+
+  describe('formatEquity', () => {
+    it('formats large equity', () => {
+      expect(formatEquity(1250000)).toBe('$1,250,000');
+    });
+  });
+
+  describe('window status helpers', () => {
+    it('reports near end and complete states', () => {
+      expect(isNearEndOfWindow(100)).toBe(false);
+      expect(isNearEndOfWindow(110)).toBe(true);
+      expect(isWindowComplete(100)).toBe(false);
+      expect(isWindowComplete(120)).toBe(true);
+    });
+  });
+});

--- a/algolens-frontend/src/domain/portfolio/incubationUtils.ts
+++ b/algolens-frontend/src/domain/portfolio/incubationUtils.ts
@@ -1,0 +1,115 @@
+/**
+ * Incubation utility functions: formatting, progress calculation, validation.
+ *
+ * Pure functions for the incubation UI. No side effects.
+ */
+
+// Incubation window: strategies are observed for 3-4 months
+export const INCUBATION_WINDOW_DAYS = 120;
+
+export function calculateIncubationProgress(
+  daysElapsed: number,
+  windowDays: number = INCUBATION_WINDOW_DAYS
+): number {
+  if (windowDays <= 0) return 0;
+  const progress = (daysElapsed / windowDays) * 100;
+  return Math.min(Math.max(progress, 0), 100);
+}
+
+export function calculateDaysRemaining(
+  daysElapsed: number,
+  windowDays: number = INCUBATION_WINDOW_DAYS
+): number {
+  return Math.max(windowDays - daysElapsed, 0);
+}
+
+export function formatIncubationDate(date: string | Date | null): string {
+  if (!date) return 'N/A';
+
+  const d = typeof date === 'string' ? new Date(date) : date;
+  if (Number.isNaN(d.getTime())) return 'Invalid';
+
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function formatMockCapital(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '$0';
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function validateMockCapital(value: unknown): [boolean, string] {
+  let numericValue = value;
+  if (typeof numericValue === 'string') {
+    numericValue = parseFloat(numericValue);
+  }
+
+  if (typeof numericValue !== 'number' || Number.isNaN(numericValue)) {
+    return [false, 'Mock capital must be a number'];
+  }
+
+  if (numericValue <= 0) {
+    return [false, 'Mock capital must be greater than zero'];
+  }
+
+  if (numericValue < 100000) {
+    return [false, 'Mock capital must be at least $100,000'];
+  }
+
+  return [true, ''];
+}
+
+export function validateReason(reason: unknown): [boolean, string] {
+  if (typeof reason !== 'string') {
+    return [false, 'Reason must be text'];
+  }
+
+  const trimmed = reason.trim();
+  if (!trimmed) {
+    return [false, 'Reason cannot be empty'];
+  }
+
+  if (trimmed.length < 10) {
+    return [false, 'Reason must be at least 10 characters'];
+  }
+
+  if (trimmed.length > 500) {
+    return [false, 'Reason must not exceed 500 characters'];
+  }
+
+  return [true, ''];
+}
+
+export function formatEquity(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '$0';
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function isNearEndOfWindow(
+  daysElapsed: number,
+  windowDays: number = INCUBATION_WINDOW_DAYS
+): boolean {
+  return daysElapsed >= windowDays - 14;
+}
+
+export function isWindowComplete(
+  daysElapsed: number,
+  windowDays: number = INCUBATION_WINDOW_DAYS
+): boolean {
+  return daysElapsed >= windowDays;
+}

--- a/algolens-frontend/src/infrastructure/api/portfolioApi.ts
+++ b/algolens-frontend/src/infrastructure/api/portfolioApi.ts
@@ -1,4 +1,5 @@
 import type { Strategy, PortfolioData, HistoricalDataPoint } from '../../domain/portfolio/portfolioData';
+import type { IncubatingStrategy, IncubationPerformance } from '../../domain/portfolio/incubationData';
 import { API_BASE_URL, log } from './httpClient';
 
 export class PortfolioApiService {
@@ -169,6 +170,22 @@ export class PortfolioApiService {
     const response = await this.fetchWithAuth(`${API_BASE_URL}/portfolio/strategies`);
     const data = await response.json();
     return data.strategies;
+  }
+
+  static async getIncubationStrategies(): Promise<IncubatingStrategy[]> {
+    const response = await this.fetchWithAuth(`${API_BASE_URL}/portfolio/incubation`);
+    const data = await response.json();
+    return data.incubating_strategies || [];
+  }
+
+  static async getIncubationPerformance(strategyId: string): Promise<IncubationPerformance> {
+    const encodedId = encodeURIComponent(strategyId);
+    const response = await this.fetchWithAuth(`${API_BASE_URL}/portfolio/incubation/${encodedId}/performance`);
+    const data = await response.json();
+    return {
+      positions: data.positions || [],
+      equity_curve: data.equity_curve || [],
+    };
   }
 
   static async getPortfolioData(): Promise<PortfolioData> {


### PR DESCRIPTION
Adds a member-only **Incubation** tab that mirrors the portfolio screen but shows strategies in the `incubating` lifecycle (running on mock capital, walled off from the live book). Built into the new DDD layout (`algolens-api` hexagonal layers + `algolens-frontend` layered), scoped to just incubation.

### Backend (`algolens-api`) — 46 tests pass
- `migrations/002_strategy_lifecycle.sql` — `lifecycle` state machine (live/incubating/retired) + audit log
- `domain/portfolio/incubation.py` — pure window/progress math (takes `now`; passes the AST boundary test)
- `application/portfolio` — `ListIncubatingStrategies`, `GetIncubationPerformance`, start/promote/retire + repo ports
- `infrastructure/portfolio` — incubation reads/writes + audit inserts; the live registry read excludes non-`live` rows **and tolerates a DB where migration 002 hasn't run** (detects the `lifecycle` column, falls back to the legacy query + built-in default) so the live dashboard never breaks
- `adapters/http` — `GET /portfolio/incubation`, `/incubation/<id>/performance` (+ transitions), all behind `@jwt_required` and a **default-deny `internal_only`** gate (roles `admin`/`general_member`)

### Frontend (`algolens-frontend`) — 31 tests pass
- `domain/portfolio` — incubation types + pure `incubationUtils` (with tests)
- `infrastructure/api` + `application` — incubation list + performance fetchers
- `components` — `IncubationScreen` → Overview/List/Detail, styled after the portfolio screen
- Member-gated tab in `Header` (desktop) + `BottomNav` (mobile) by user role, with defense-in-depth guards in `Dashboard`

Layer-boundary tests (backend AST + frontend `architectureBoundaries`) still pass. Existing behavior preserved.

**Deploy note:** apply `migrations/002_strategy_lifecycle.sql` to each database to surface incubation data; the code degrades safely until then.